### PR TITLE
Add support for oneOf, anyOf and not

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Field Name | Type | Description
 <a name="contactObjectUrl"></a>url | `string` | The URL pointing to the contact information. MUST be in the format of a URL.
 <a name="contactObjectEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Contact Object Example:
 
@@ -252,7 +252,7 @@ Field Name | Type | Description
 <a name="licenseObjectName"></a>name | `string` | **Required.** The license name used for the API.
 <a name="licenseObjectUrl"></a>url | `string` | A URL to the license used for the API. MUST be in the format of a URL.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### License Object Example:
 
@@ -448,7 +448,7 @@ Field Pattern | Type | Description
 ---|:---:|---
 <a name="topicsObjectTopic"></a>^[^.]{topic} | [Topic Item Object](#topicItemObject) | A relative path to an individual topic. The field name MUST NOT begin with a dot. [Topic templating](#definitionsTopicTemplating) is allowed.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Topics Object Example
 
@@ -480,10 +480,10 @@ Describes the operations available on a single topic.
 Field Name | Type | Description
 ---|:---:|---
 <a name="topicItemObjectRef"></a>$ref | `string` | Allows for an external definition of this topic item. The referenced structure MUST be in the format of a [Topic Item Object](#topicItemObject). If there are conflicts between the referenced definition and this Topic Item's definition, the behavior is *undefined*.
-<a name="topicItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) | A definition of the message a SUBSCRIBE operation will receive on this topic.
-<a name="topicItemObjectPublish"></a>publish | [Message Object](#messageObject) | A definition of the message a PUBLISH operation will receive on this topic.
+<a name="topicItemObjectSubscribe"></a>subscribe | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a SUBSCRIBE operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
+<a name="topicItemObjectPublish"></a>publish | [Message Object](#messageObject) &#124; Map[`"oneOf"`, [[Message Object](#messageObject)]] | A definition of the message a PUBLISH operation will receive on this topic. `oneOf` is allowed here to specify multiple messages, however, **a message MUST be valid only against one of the referenced message objects.**
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Topic Item Object Example
 
@@ -520,6 +520,28 @@ subscribe:
         $ref: "#/components/schemas/signup"
 ```
 
+Using `oneOf` to specify multiple messages per operation:
+
+```json
+{
+  "subscribe": {
+    "oneOf": [
+      { "$ref": "#/components/messages/signup" },
+      { "$ref": "#/components/messages/login" }
+    ]
+  }
+}
+```
+
+```yaml
+subscribe:
+  oneOf:
+    - $ref: '#/components/messages/signup'
+    - $ref: '#/components/messages/login'
+```
+
+
+
 
 
 #### <a name="messageObject"></a>Message Object
@@ -537,7 +559,7 @@ Field Name | Type | Description
 <a name="messageObjectTags"></a>tags | [[Tag Object](#tagObject)] | A list of tags for API documentation control. Tags can be used for logical grouping of messages.
 <a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this message.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Message Object Example
 
@@ -614,7 +636,7 @@ Field Name | Type | Description
 <a name="tagObjectDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="tagObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this tag.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### Tag Object Example
 
@@ -647,7 +669,7 @@ Field Name | Type | Description
 <a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
 <a name="externalDocUrl"></a>url | `string` | **Required.** The URL for the target documentation. Value MUST be in the format of a URL.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### External Documentation Object Example
 
@@ -841,7 +863,7 @@ This object is an extended subset of the [JSON Schema Specification Wright Draft
 Further information about the properties can be found in [JSON Schema Core](https://tools.ietf.org/html/draft-wright-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00).
 Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here.
 
-##### Properties 
+##### Properties
 
 The following properties are taken directly from the JSON Schema definition and follow the same specifications:
 
@@ -862,7 +884,7 @@ The following properties are taken directly from the JSON Schema definition and 
 - required
 - enum
 
-The following properties are taken from the JSON Schema definition but their definitions were adjusted to the AsyncAPI Specification. 
+The following properties are taken from the JSON Schema definition but their definitions were adjusted to the AsyncAPI Specification.
 - type - Value MUST be a string. Multiple types via an array are not supported.
 - allOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
 - oneOf - Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard JSON Schema.
@@ -889,16 +911,16 @@ Field Name | Type | Description
 <a name="schemaObjectReadOnly"></a>readOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If property is marked as `readOnly` being `true` and is in the `required` list, the `required` will take effect on the response only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaObjectWriteOnly"></a>writeOnly | `boolean` | Relevant only for Schema `"properties"` definitions. Declares the property as "write only". This means that it MAY be sent as part of a request but SHOULD NOT be sent as part of the response. If property is marked as `writeOnly` being `true` and is in the `required` list, the `required` will take effect on the request only. A property MUST NOT be marked as both `readOnly` and `writeOnly` being `true`. Default value is `false`.
 <a name="schemaObjectXml"></a>xml | [XML Object](#xmlObject) | This MAY be used only on properties schemas. It has no effect on root schemas. Adds Additional metadata to describe the XML representation format of this property.
-<a name="schemaObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema. 
+<a name="schemaObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) | Additional external documentation for this schema.
 <a name="schemaObjectExample"></a>example | Any | A free-form property to include an example of an instance for this schema. To represent examples that cannot naturally represented in JSON or YAML, a string value can be used to contain the example with escaping where necessary.
 <a name="schemaObjectDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
 
 The AsyncAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
-`allOf` takes in an array of object definitions that are validated *independently* but together compose a single object. 
+`allOf` takes in an array of object definitions that are validated *independently* but together compose a single object.
 
 While composition offers model extensibility, it does not imply a hierarchy between the models.
 To support polymorphism, AsyncAPI Specification adds the support of the `discriminator` field.
@@ -1246,7 +1268,7 @@ Field Name | Type | Description
 <a name="xmlObjectAttribute"></a>attribute | `boolean` | Declares whether the property definition translates to an attribute instead of an element. Default value is `false`.
 <a name="xmlObjectWrapped"></a>wrapped | `boolean` | MAY be used only for an array definition. Signifies whether the array is wrapped (for example, `<books><book/><book/></books>`) or unwrapped (`<book/><book/>`). Default value is `false`. The definition takes effect only when defined alongside `type` being `array` (outside the `items`).
 
-This object can be extended with [Specification Extensions](#specificationExtensions). 
+This object can be extended with [Specification Extensions](#specificationExtensions).
 
 ##### XML Object Examples
 

--- a/schema/asyncapi.json
+++ b/schema/asyncapi.json
@@ -395,6 +395,23 @@
             "$ref": "#/definitions/schema"
           }
         },
+        "oneOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "anyOf": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "not": {
+          "$ref": "#/definitions/schema"
+        },
         "properties": {
           "type": "object",
           "additionalProperties": {
@@ -478,16 +495,40 @@
           "type": "string"
         },
         "publish": {
-          "$ref": "#/definitions/message"
+          "$ref": "#/definitions/operation"
         },
         "subscribe": {
-          "$ref": "#/definitions/message"
+          "$ref": "#/definitions/operation"
         },
         "deprecated": {
           "type": "boolean",
           "default": false
         }
       }
+    },
+    "operation": {
+      "oneOf": [
+        { "$ref": "#/definitions/message" },
+        {
+          "type": "object",
+          "required": [ "oneOf" ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^x-": {
+              "$ref": "#/definitions/vendorExtension"
+            }
+          },
+          "properties": {
+            "oneOf": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "$ref": "#/definitions/message"
+              }
+            }
+          }
+        }
+      ]
     },
     "message": {
       "type": "object",

--- a/test/docs/anyof.yml
+++ b/test/docs/anyof.yml
@@ -1,0 +1,29 @@
+asyncapi: '1.0.0'
+info:
+  title: AnyOf example
+  version: '1.0.0'
+
+topics:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+components:
+  messages:
+    testMessages:
+      payload:
+        anyOf: # anyOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
+
+  schemas:
+    objectWithKey:
+      type: object
+      properties:
+        key:
+          type: string
+    objectWithKey2:
+      type: object
+      properties:
+        key2:
+          type: string

--- a/test/docs/not.yml
+++ b/test/docs/not.yml
@@ -1,0 +1,23 @@
+asyncapi: '1.0.0'
+info:
+  title: Not example
+  version: '1.0.0'
+
+topics:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+components:
+  messages:
+    testMessages:
+      payload:
+        $ref: "#/components/schemas/testSchema"
+
+  schemas:
+    testSchema:
+      type: object
+      properties:
+        key:
+          not:
+            type: integer

--- a/test/docs/oneof.yml
+++ b/test/docs/oneof.yml
@@ -1,0 +1,44 @@
+asyncapi: '1.0.0'
+info:
+  title: OneOf example
+  version: '1.0.0'
+
+topics:
+  test:
+    publish:
+      $ref: '#/components/messages/testMessages'
+
+  test2:
+    subscribe:
+      # Use oneOf here if different messages are published on test2 topic.
+      oneOf:
+        - payload:
+            $ref: "#/components/schemas/objectWithKey"
+        - payload:
+            $ref: "#/components/schemas/objectWithKey2"
+
+components:
+  messages:
+    testMessages:
+      payload:
+        oneOf: # oneOf in payload schema
+          - $ref: "#/components/schemas/objectWithKey"
+          - $ref: "#/components/schemas/objectWithKey2"
+    testMessage1:
+      payload:
+        $ref: "#/components/schemas/objectWithKey"
+    testMessage2:
+      payload:
+        $ref: "#/components/schemas/objectWithKey2"
+
+  schemas:
+    objectWithKey:
+      type: object
+      properties:
+        key:
+          type: string
+    objectWithKey2:
+      type: object
+      properties:
+        key2:
+          type: string


### PR DESCRIPTION
It fixes #38 and fixes #58.

**Changes:**

- Adds support for `oneOf`, `anyOf` and `not` on schemas.
- Adds support for `oneOf` on operation objects, i.e. publish/subscribe.

This PR is part of the 1.1.0 release.