### PR TITLE
docs(spec): remove unknown key-value pair

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1414,7 +1414,6 @@ my.org.User
   },
   "parameters": {
     "userId": {
-      "name": "userId",
       "description": "Id of the user.",
       "schema": {
         "type": "string"
@@ -1487,7 +1486,6 @@ components:
             $ref: "#/components/schemas/signup"
   parameters:
     userId:
-    - name: userId
       description: Id of the user.
       schema:
         type: string


### PR DESCRIPTION
According to specification no `name` field exists within Parameter Object.