### PR TITLE
docs: add example for websocket with bindings

### DIFF
--- a/examples/2.0.0/websocket-gemini.yml
+++ b/examples/2.0.0/websocket-gemini.yml
@@ -37,7 +37,7 @@ externalDocs:
 # Details on how to connect to the application
 #
 servers:
-  swamp:
+  public:
     url: wss://api.gemini.com
     protocol: wss
 

--- a/examples/2.0.0/websocket-gemini.yml
+++ b/examples/2.0.0/websocket-gemini.yml
@@ -1,0 +1,205 @@
+#
+#
+#
+#This example showcases usage of AsyncAPI for the purpose of describing a WebSocket API. It is based on a real public service maintained by company called Gemini that provides cryptocurency trading products. It uses AsyncAPI bindings.
+
+#This AsyncAPI document describes their v1 of the API. The v2 is also available and changes in the way that it provides a multimessage channel, where you subscribe for messages by sending a subscription message instead of using query parameters. For example with multimessage channel check out this article https://www.asyncapi.com/blog/websocket-part2 about another real public API called Kraken
+#
+#
+#
+
+asyncapi: 2.0.0
+
+#
+# Overal information for users of the application
+#
+info:
+  title: Gemini Market Data Websocket API
+  version: '1.0.0'
+  contact:
+    name: Gemini
+    url: https://www.gemini.com/
+  description: |
+    Market data is a public API that streams all the market data on a given symbol.
+    
+    You can quickly play with the API using [websocat](https://github.com/vi/websocat#installation) like this:
+    ```bash
+    websocat wss://api.gemini.com/v1/marketdata/btcusd?heartbeat=true -S
+    ```
+    
+#
+# Link to external docs
+#
+externalDocs:
+  url: https://docs.sandbox.gemini.com/websocket-api/#market-data
+    
+#
+# Details on how to connect to the application
+#
+servers:
+  swamp:
+    url: wss://api.gemini.com
+    protocol: wss
+
+#
+# Details about all the channels that you can listen to or send to messages
+#
+channels:
+  /v1/marketdata/{symbol}:
+    parameters:
+      symbol:
+        description: |
+          Symbols are formatted as CCY1CCY2 where prices are in CCY2 and quantities are in CCY1. To read more click [here](https://docs.sandbox.gemini.com/websocket-api/#symbols-and-minimums).
+        schema:
+          type: string
+          enum: ['btcusd', 'ethbtc', 'ethusd', 'zecusd', 'zecbtc', 'zeceth', 'zecbch', 'zecltc', 'bchusd', 'bchbtc', 'bcheth', 'ltcusd', 'ltcbtc', 'ltceth', 'ltcbch', 'batusd', 'daiusd', 'linkusd', 'oxtusd', 'batbtc', 'linkbtc', 'oxtbtc', 'bateth', 'linketh', 'oxteth', 'ampusd', 'compusd', 'paxgusd', 'mkrusd', 'zrxusd', 'kncusd', 'manausd', 'storjusd', 'snxusd', 'crvusd', 'balusd', 'uniusd', 'renusd', 'umausd', 'yfiusd', 'btcdai', 'ethdai', 'aaveusd', 'filusd', 'btceur', 'btcgbp', 'etheur', 'ethgbp', 'btcsgd', 'ethsgd', 'sklusd', 'grtusd', 'bntusd', '1inchusd', 'enjusd', 'lrcusd', 'sandusd', 'cubeusd', 'lptusd', 'bondusd', 'maticusd', 'injusd', 'sushiusd']
+    bindings:
+      ws:
+        bindingVersion: 0.1.0
+        query:
+          type: object
+          description: |
+            The semantics of entry type filtering is:
+
+            If any entry type is specified as true or false, all of them must be explicitly flagged true to show up in the response
+            If no entry types filtering parameters are included in the url, then all entry types will appear in the response
+
+            NOTE: top_of_book has no meaning and initial book events are empty when only trades is specified
+          properties:
+            heartbeat:
+              type: boolean
+              default: false
+              description: Optionally add this parameter and set to true to receive a heartbeat every 5 seconds
+            top_of_book:
+              type: boolean
+              default: false
+              description: If absent or false, receive full order book depth; if present and true, receive top of book only. Only applies to bids and offers.
+            bids:
+              type: boolean
+              default: true
+              description: Include bids in change events
+            offers:
+              type: boolean
+              default: true
+              description: Include asks in change events
+            trades:
+              type: boolean
+              default: true
+              description: Include trade events
+            auctions:
+              type: boolean
+              default: true
+              description: Include auction events
+    subscribe:
+      summary: Receive market updates on a given symbol
+      message:
+        $ref: '#/components/messages/marketData'
+
+#
+# All reusable parts for readability and staying DRY
+#
+components:
+  messages:
+    marketData:
+      summary: Message with marked data information.
+      description: |
+        The initial response message will show the existing state of the order book. Subsequent messages will show all executed trades, as well as all other changes to the order book from orders placed or canceled.
+      payload:
+        $ref: '#/components/schemas/market'
+      examples:
+        - payload:
+            type: update
+            eventId: 36902233362
+            timestamp: 1619769673
+            timestampms: 1619769673527
+            socket_sequence: 661
+            events:
+              - type: change
+                side: bid
+                price: '54350.40'
+                remaining: '0.002'
+                delta: '0.002'
+                reason: place
+        - payload:
+            type: heartbeat
+            socket_sequence: 1656
+  schemas:
+    market:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/heartbeat'
+        - $ref: '#/components/schemas/update'
+    heartbeat:
+      allOf:
+        - properties:
+            type:
+              type: string
+              const: heartbeat
+          required:
+            - type
+        - $ref: '#/components/schemas/default'
+    update:
+      allOf:
+        - properties:
+            type:
+              type: string
+              const: update
+            eventId:
+              type: integer
+              description: A monotonically increasing sequence number indicating when this change occurred. These numbers are persistent and consistent between market data connections.
+            events:
+              $ref: '#/components/schemas/events'
+            timestamp:
+              type: string
+              format: date-time
+              description: The timestamp in seconds for this group of events (included for compatibility reasons). We recommend using the timestampms field instead.
+            timestampms:
+              type: string
+              format: time
+              description: The timestamp in milliseconds for this group of events.
+          required:
+            - type
+            - eventId
+            - events
+            - timestamp
+            - timestampms
+        - $ref: '#/components/schemas/default'
+    default:
+      type: object
+      description: This object is always part of the payload. In case of type=heartbeat, these are the only fields.
+      required:
+         - type
+         - socket_sequence
+      properties:
+        socket_sequence:
+          type: integer
+          description: zero-indexed monotonic increasing sequence number attached to each message sent - if there is a gap in this sequence, you have missed a message. If you choose to enable heartbeats, then heartbeat and update messages will share a single increasing sequence. See [Sequence Numbers](https://docs.sandbox.gemini.com/websocket-api/#sequence-numbers) for more information.
+    events:
+      type: array
+      description: Either a change to the order book, or the indication that a trade has occurred.
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          type:
+            type: string
+            enum: ['trade', 'change', 'auction, block_trade']
+          price:
+            type: number
+            multipleOf: 1.000
+            description: The price of this order book entry.
+          side:
+            type: string
+            enum: ['bid', 'side']
+          reason:
+            type: string
+            enum: ['place', 'trade', 'cancel', 'initial']
+            description: Indicates why the change has occurred. initial is for the initial response message, which will show the entire existing state of the order book.
+          remaining: 
+            type: number
+            multipleOf: 1.000
+            description: The quantity remaining at that price level after this change occurred. May be zero if all orders at this price level have been filled or canceled.
+          delta:
+            type: number
+            multipleOf: 1.000
+            description: The quantity changed. May be negative, if an order is filled or canceled. For initial messages, delta will equal remaining.


### PR DESCRIPTION
adding a missing websocket example that many people ask for

preview here: https://playground.asyncapi.io/?url=https://raw.githubusercontent.com/derberg/asyncapi/add-websocket-example/examples/2.0.0/websocket-gemini.yml