### PR TITLE
chore: add release pipeline for the spec

### DIFF
--- a/.github/workflows/.releaserc
+++ b/.github/workflows/.releaserc
@@ -1,0 +1,11 @@
+---
+branches:
+- master
+- name: .+release
+  prerelease: true
+plugins:
+- - "@semantic-release/commit-analyzer"
+  - preset: conventionalcommits
+- - "@semantic-release/release-notes-generator"
+  - preset: conventionalcommits
+- - "@semantic-release/github"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - '**-release'
+
+jobs:
+  release:
+    name: 'Release to GitHub'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+      - name: Add plugin for conventional commits
+        run: npm install conventional-changelog-conventionalcommits
+        working-directory: ./.github/workflows
+      - name: Release to GitHub
+        working-directory: ./.github/workflows
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_AUTHOR_NAME: asyncapi-bot
+          GIT_AUTHOR_EMAIL: info@asyncapi.io
+          GIT_COMMITTER_NAME: asyncapi-bot
+          GIT_COMMITTER_EMAIL: info@asyncapi.io
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - master
       - '**-release'
-
+ 
 jobs:
   release:
-    name: 'Release to GitHub'
+    name: 'Release to GitHub' 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -17,13 +17,11 @@ jobs:
         uses: actions/setup-node@v1
       - name: Add plugin for conventional commits
         run: npm install conventional-changelog-conventionalcommits
-        working-directory: ./.github/workflows
       - name: Release to GitHub
-        working-directory: ./.github/workflows
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
-        run: npx semantic-release
+        run: npx semantic-release@17.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release the spec
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
  
 jobs:
   release:
-    name: 'Release to GitHub' 
+    name: 'Create GitHub release' 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.releaserc
+++ b/.releaserc
@@ -1,11 +1,11 @@
 ---
 branches:
 - master
-- name: .+release
+- name: 2021-06-release
   prerelease: true
 plugins:
 - - "@semantic-release/commit-analyzer"
-  - preset: conventionalcommits
+  - preset: conventionalcommits 
 - - "@semantic-release/release-notes-generator"
   - preset: conventionalcommits
 - - "@semantic-release/github"


### PR DESCRIPTION
This PR introduces release automation for the spec using conventional commits spec and following the release cadence agreement.

assumptions:
- all changes for release happen in release branch and every change in release branch produces a prerelease
- merge from release into master branch triggers normal release, like minor or major
- it is possible to merge from just a fork with for example `fix` PR and trigger patch release

See also: https://github.com/asyncapi/spec/issues/536

---

Commit like `fix: spelling mistake in Operations object description` to master branch

![Screenshot 2021-05-19 at 13 43 10](https://user-images.githubusercontent.com/6995927/118807293-61d07500-b8a8-11eb-9565-b6a0a1cd764a.png)

Results in a patch release (base was 2.0.1):
![Screenshot 2021-05-19 at 13 45 21](https://user-images.githubusercontent.com/6995927/118807386-8593bb00-b8a8-11eb-940c-39f51429a4f1.png)

Commit like `feat: add something new in some non-release branch` added to branch that doesn't't follow pattern with `-release` suffx

![Screenshot 2021-05-19 at 14 36 21](https://user-images.githubusercontent.com/6995927/118813664-a90e3400-b8af-11eb-9956-c2228d369396.png)

did not trigger a release

Commit like `feat: add something new in release branch` is a branch that has `2021-06-release` suffix 

![Screenshot 2021-05-19 at 15 56 57](https://user-images.githubusercontent.com/6995927/118825360-e62bf380-b8ba-11eb-91ce-51a77c697016.png)


Results in proper pre release `v2.1.0-2021-06-release.1`

![Screenshot 2021-05-19 at 15 55 19](https://user-images.githubusercontent.com/6995927/118825066-a8c76600-b8ba-11eb-89da-057ee013268d.png)

Another commit to release branch `feat: add something more in release branch` doesn't close bump from 2.1 to 2.2 but proper bump of suffix from 1 to 2

![Screenshot 2021-05-19 at 16 02 47](https://user-images.githubusercontent.com/6995927/118826341-b2050280-b8bb-11eb-9c80-e4bb0107dca3.png)
