### PR TITLE
fix: clarify support for Boolean JSON Schemas

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+      # below lines are not enough to have release supported for these branches
+      # make sure configuration of `semantic-release` package mentiones these branches
+      - next
+      - '**-release'
 
 jobs:
 

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -13,10 +13,13 @@ jobs:
     name: Generate assets and bump
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: master
+          # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
+          # in case release is created from release branch then we need to checkout from given branch
+          # if @semantic-release/github is used to publish, the minimum version is 7.2.0 for proper working
+          ref: ${{ github.event.release.target_commitish }}
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release the spec
+
+on:
+  push:
+    branches:
+      - master
+      - '**-release'
+ 
+jobs:
+  release:
+    name: 'Create GitHub release' 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+      - name: Add plugin for conventional commits
+        run: npm install conventional-changelog-conventionalcommits
+      - name: Release to GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_AUTHOR_NAME: asyncapi-bot
+          GIT_AUTHOR_EMAIL: info@asyncapi.io
+          GIT_COMMITTER_NAME: asyncapi-bot
+          GIT_COMMITTER_EMAIL: info@asyncapi.io
+        run: npx semantic-release@17.4.3

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,11 @@
+---
+branches:
+- master
+- name: 2021-06-release
+  prerelease: true
+plugins:
+- - "@semantic-release/commit-analyzer"
+  - preset: conventionalcommits 
+- - "@semantic-release/release-notes-generator"
+  - preset: conventionalcommits
+- - "@semantic-release/github"

--- a/examples/2.0.0/websocket-gemini.yml
+++ b/examples/2.0.0/websocket-gemini.yml
@@ -1,11 +1,15 @@
 #
 #
 #
-#This example showcases usage of AsyncAPI for the purpose of describing a WebSocket API. It is based on a real public service maintained by company called Gemini that provides cryptocurency trading products. It uses AsyncAPI bindings.
-
-#This AsyncAPI document describes their v1 of the API. The v2 is also available and changes in the way that it provides a multimessage channel, where you subscribe for messages by sending a subscription message instead of using query parameters. For example with multimessage channel check out this article https://www.asyncapi.com/blog/websocket-part2 about another real public API called Kraken
+# This example showcases usage of AsyncAPI for the purpose of describing a WebSocket API. It is based on a real public service maintained by company called Gemini that provides cryptocurency trading products. It uses AsyncAPI bindings.
 #
+# This AsyncAPI document describes their v1 of the API. The v2 is also available and changes in the way that it provides a multimessage channel, where you subscribe for messages by sending a subscription message instead of using query parameters. For example with multimessage channel check out this article https://www.asyncapi.com/blog/websocket-part2 about another real public API called Kraken
 #
+# All available learning materials about AsyncAPI and WebSocket are:
+# - WebSocket, Shrek, and AsyncAPI - An Opinionated Intro article: https://www.asyncapi.com/blog/websocket-part1
+# - Creating AsyncAPI for WebSocket API - Step by Step article: https://www.asyncapi.com/blog/websocket-part2
+# - From API-First to Code Generation - A WebSocket Use Case article: https://www.asyncapi.com/blog/websocket-part3
+# - Live stream about topics mentioned in part 1 and 2 articles: https://www.youtube.com/watch?v=8tFBcf31e_c
 #
 
 asyncapi: 2.0.0

--- a/examples/2.0.0/websocket-gemini.yml
+++ b/examples/2.0.0/websocket-gemini.yml
@@ -1,0 +1,205 @@
+#
+#
+#
+#This example showcases usage of AsyncAPI for the purpose of describing a WebSocket API. It is based on a real public service maintained by company called Gemini that provides cryptocurency trading products. It uses AsyncAPI bindings.
+
+#This AsyncAPI document describes their v1 of the API. The v2 is also available and changes in the way that it provides a multimessage channel, where you subscribe for messages by sending a subscription message instead of using query parameters. For example with multimessage channel check out this article https://www.asyncapi.com/blog/websocket-part2 about another real public API called Kraken
+#
+#
+#
+
+asyncapi: 2.0.0
+
+#
+# Overal information for users of the application
+#
+info:
+  title: Gemini Market Data Websocket API
+  version: '1.0.0'
+  contact:
+    name: Gemini
+    url: https://www.gemini.com/
+  description: |
+    Market data is a public API that streams all the market data on a given symbol.
+    
+    You can quickly play with the API using [websocat](https://github.com/vi/websocat#installation) like this:
+    ```bash
+    websocat wss://api.gemini.com/v1/marketdata/btcusd?heartbeat=true -S
+    ```
+    
+#
+# Link to external docs
+#
+externalDocs:
+  url: https://docs.sandbox.gemini.com/websocket-api/#market-data
+    
+#
+# Details on how to connect to the application
+#
+servers:
+  public:
+    url: wss://api.gemini.com
+    protocol: wss
+
+#
+# Details about all the channels that you can listen to or send to messages
+#
+channels:
+  /v1/marketdata/{symbol}:
+    parameters:
+      symbol:
+        description: |
+          Symbols are formatted as CCY1CCY2 where prices are in CCY2 and quantities are in CCY1. To read more click [here](https://docs.sandbox.gemini.com/websocket-api/#symbols-and-minimums).
+        schema:
+          type: string
+          enum: ['btcusd', 'ethbtc', 'ethusd', 'zecusd', 'zecbtc', 'zeceth', 'zecbch', 'zecltc', 'bchusd', 'bchbtc', 'bcheth', 'ltcusd', 'ltcbtc', 'ltceth', 'ltcbch', 'batusd', 'daiusd', 'linkusd', 'oxtusd', 'batbtc', 'linkbtc', 'oxtbtc', 'bateth', 'linketh', 'oxteth', 'ampusd', 'compusd', 'paxgusd', 'mkrusd', 'zrxusd', 'kncusd', 'manausd', 'storjusd', 'snxusd', 'crvusd', 'balusd', 'uniusd', 'renusd', 'umausd', 'yfiusd', 'btcdai', 'ethdai', 'aaveusd', 'filusd', 'btceur', 'btcgbp', 'etheur', 'ethgbp', 'btcsgd', 'ethsgd', 'sklusd', 'grtusd', 'bntusd', '1inchusd', 'enjusd', 'lrcusd', 'sandusd', 'cubeusd', 'lptusd', 'bondusd', 'maticusd', 'injusd', 'sushiusd']
+    bindings:
+      ws:
+        bindingVersion: 0.1.0
+        query:
+          type: object
+          description: |
+            The semantics of entry type filtering is:
+
+            If any entry type is specified as true or false, all of them must be explicitly flagged true to show up in the response
+            If no entry types filtering parameters are included in the url, then all entry types will appear in the response
+
+            NOTE: top_of_book has no meaning and initial book events are empty when only trades is specified
+          properties:
+            heartbeat:
+              type: boolean
+              default: false
+              description: Optionally add this parameter and set to true to receive a heartbeat every 5 seconds
+            top_of_book:
+              type: boolean
+              default: false
+              description: If absent or false, receive full order book depth; if present and true, receive top of book only. Only applies to bids and offers.
+            bids:
+              type: boolean
+              default: true
+              description: Include bids in change events
+            offers:
+              type: boolean
+              default: true
+              description: Include asks in change events
+            trades:
+              type: boolean
+              default: true
+              description: Include trade events
+            auctions:
+              type: boolean
+              default: true
+              description: Include auction events
+    subscribe:
+      summary: Receive market updates on a given symbol
+      message:
+        $ref: '#/components/messages/marketData'
+
+#
+# All reusable parts for readability and staying DRY
+#
+components:
+  messages:
+    marketData:
+      summary: Message with marked data information.
+      description: |
+        The initial response message will show the existing state of the order book. Subsequent messages will show all executed trades, as well as all other changes to the order book from orders placed or canceled.
+      payload:
+        $ref: '#/components/schemas/market'
+      examples:
+        - payload:
+            type: update
+            eventId: 36902233362
+            timestamp: 1619769673
+            timestampms: 1619769673527
+            socket_sequence: 661
+            events:
+              - type: change
+                side: bid
+                price: '54350.40'
+                remaining: '0.002'
+                delta: '0.002'
+                reason: place
+        - payload:
+            type: heartbeat
+            socket_sequence: 1656
+  schemas:
+    market:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/heartbeat'
+        - $ref: '#/components/schemas/update'
+    heartbeat:
+      allOf:
+        - properties:
+            type:
+              type: string
+              const: heartbeat
+          required:
+            - type
+        - $ref: '#/components/schemas/default'
+    update:
+      allOf:
+        - properties:
+            type:
+              type: string
+              const: update
+            eventId:
+              type: integer
+              description: A monotonically increasing sequence number indicating when this change occurred. These numbers are persistent and consistent between market data connections.
+            events:
+              $ref: '#/components/schemas/events'
+            timestamp:
+              type: string
+              format: date-time
+              description: The timestamp in seconds for this group of events (included for compatibility reasons). We recommend using the timestampms field instead.
+            timestampms:
+              type: string
+              format: time
+              description: The timestamp in milliseconds for this group of events.
+          required:
+            - type
+            - eventId
+            - events
+            - timestamp
+            - timestampms
+        - $ref: '#/components/schemas/default'
+    default:
+      type: object
+      description: This object is always part of the payload. In case of type=heartbeat, these are the only fields.
+      required:
+         - type
+         - socket_sequence
+      properties:
+        socket_sequence:
+          type: integer
+          description: zero-indexed monotonic increasing sequence number attached to each message sent - if there is a gap in this sequence, you have missed a message. If you choose to enable heartbeats, then heartbeat and update messages will share a single increasing sequence. See [Sequence Numbers](https://docs.sandbox.gemini.com/websocket-api/#sequence-numbers) for more information.
+    events:
+      type: array
+      description: Either a change to the order book, or the indication that a trade has occurred.
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          type:
+            type: string
+            enum: ['trade', 'change', 'auction, block_trade']
+          price:
+            type: number
+            multipleOf: 1.000
+            description: The price of this order book entry.
+          side:
+            type: string
+            enum: ['bid', 'side']
+          reason:
+            type: string
+            enum: ['place', 'trade', 'cancel', 'initial']
+            description: Indicates why the change has occurred. initial is for the initial response message, which will show the entire existing state of the order book.
+          remaining: 
+            type: number
+            multipleOf: 1.000
+            description: The quantity remaining at that price level after this change occurred. May be zero if all orders at this price level have been filled or canceled.
+          delta:
+            type: number
+            multipleOf: 1.000
+            description: The quantity changed. May be negative, if an order is filled or canceled. For initial messages, delta will equal remaining.

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -839,7 +839,7 @@ Describes a parameter included in a channel name.
 Field Name | Type | Description
 ---|:---:|---
 <a name="parameterObjectDescription"></a>description | `string` | A verbose explanation of the parameter. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Definition of the parameter.
+<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Definition of the parameter.
 location | `string` | A [runtime expression](#runtimeExpression) that specifies the location of the parameter value. Even when a definition for the target field exists, it MUST NOT be used to validate this parameter but, instead, the `schema` property MUST be used.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -1001,7 +1001,7 @@ Describes a message received on a given channel and operation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
+<a name="messageObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
 <a name="messageObjectPayload"></a>payload | `any` | Definition of the message payload. It can be of any type but defaults to [Schema object](#schemaObject).
 <a name="messageObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
 <a name="messageObjectSchemaFormat"></a>schemaFormat | `string` | A string containing the name of the schema format used to define the message payload. If omitted, implementations should parse the payload as a [Schema object](#schemaObject). Check out the [supported schema formats table](#messageObjectSchemaFormatTable) for more information. Custom values are allowed but their implementation is OPTIONAL. A custom value MUST NOT refer to one of the schema formats listed in the [table](#messageObjectSchemaFormatTable).
@@ -1192,7 +1192,7 @@ If you're looking to apply traits to an operation, see the [Operation Trait Obje
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageTraitObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
+<a name="messageTraitObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
 <a name="messageTraitObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
 <a name="messageTraitObjectSchemaFormat"></a>schemaFormat | `string` | A string containing the name of the schema format/language used to define the message payload. If omitted, implementations should parse the payload as a [Schema object](#schemaObject).
 <a name="messageTraitObjectContentType"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#defaultContentTypeString) field.
@@ -1322,7 +1322,7 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject)] &#124; `boolean` | An object to hold reusable [Schema Objects](#schemaObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
@@ -1509,8 +1509,7 @@ components:
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays or be defined as boolean values. `True` means that the type can be anything, while `false` means that the given schema cannot be defined.
-This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/).
+These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/). The empty schema (which allows any instance to validate) MAY be represented by the `boolean` value `true` and a schema which allows no instance to validate MAY be represented by the `boolean` value `false`.
 
 Further information about the properties can be found in [JSON Schema Core](https://tools.ietf.org/html/draft-handrews-json-schema-01) and [JSON Schema Validation](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01).
 Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here.
@@ -1728,7 +1727,7 @@ example:
   ],
   "properties": {
     "anySchema": true,
-    "neverBeDefined.": false
+    "cannotBeDefined": false
   }
 }
 ```
@@ -1739,7 +1738,7 @@ required:
 - anySchema
 properties:
   anySchema: true
-  neverBeDefined: false
+  cannotBeDefined: false
 ```
 
 ###### Models with Composition

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -839,7 +839,7 @@ Describes a parameter included in a channel name.
 Field Name | Type | Description
 ---|:---:|---
 <a name="parameterObjectDescription"></a>description | `string` | A verbose explanation of the parameter. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | Definition of the parameter.
+<a name="parameterObjectSchema"></a>schema | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Definition of the parameter.
 location | `string` | A [runtime expression](#runtimeExpression) that specifies the location of the parameter value. Even when a definition for the target field exists, it MUST NOT be used to validate this parameter but, instead, the `schema` property MUST be used.
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
@@ -1001,7 +1001,7 @@ Describes a message received on a given channel and operation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
+<a name="messageObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
 <a name="messageObjectPayload"></a>payload | `any` | Definition of the message payload. It can be of any type but defaults to [Schema object](#schemaObject).
 <a name="messageObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
 <a name="messageObjectSchemaFormat"></a>schemaFormat | `string` | A string containing the name of the schema format used to define the message payload. If omitted, implementations should parse the payload as a [Schema object](#schemaObject). Check out the [supported schema formats table](#messageObjectSchemaFormatTable) for more information. Custom values are allowed but their implementation is OPTIONAL. A custom value MUST NOT refer to one of the schema formats listed in the [table](#messageObjectSchemaFormatTable).
@@ -1192,7 +1192,7 @@ If you're looking to apply traits to an operation, see the [Operation Trait Obje
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageTraitObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
+<a name="messageTraitObjectHeaders"></a>headers | [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) &#124; `boolean` | Schema definition of the application headers. Schema MUST be of type "object". It **MUST NOT** define the protocol headers.
 <a name="messageTraitObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
 <a name="messageTraitObjectSchemaFormat"></a>schemaFormat | `string` | A string containing the name of the schema format/language used to define the message payload. If omitted, implementations should parse the payload as a [Schema object](#schemaObject).
 <a name="messageTraitObjectContentType"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#defaultContentTypeString) field.
@@ -1322,7 +1322,7 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
+<a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject)] &#124; `boolean` | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
@@ -1509,7 +1509,7 @@ components:
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays.
+These types can be objects, but also primitives and arrays or be defined as boolean values. `True` means that the type can be anything, while `false` means that the given schema cannot be defined.
 This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/).
 
 Further information about the properties can be found in [JSON Schema Core](https://tools.ietf.org/html/draft-handrews-json-schema-01) and [JSON Schema Validation](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01).
@@ -1716,6 +1716,30 @@ required:
 example:
   name: Puma
   id: 1
+```
+
+###### Model with true/false schemas
+
+```json
+{
+  "type": "object",
+  "required": [
+    "anySchema"
+  ],
+  "properties": {
+    "anySchema": true,
+    "neverBeDefined.": false
+  }
+}
+```
+
+```yaml
+type: object
+required:
+- anySchema
+properties:
+  anySchema: true
+  neverBeDefined: false
 ```
 
 ###### Models with Composition


### PR DESCRIPTION
---
title: "Mention about true/false JSON Schemas in Schema Object"
---

As Schema Object in spec is defined as superset of the [JSON Schema Specification Draft 07](http://json-schema.org/), it would be nice to specify that the Schema Object itself can be boolean value. I know it results from the definition of draft 07, so I'd like to hear your opinion about the changes.

Description for `true/false` schemas I took from https://github.com/OAI/OpenAPI-Specification/pull/2609/files Thanks to @MikeRalphson 

---

**Related issue(s):**
https://github.com/asyncapi/parser-js/issues/232
Fixes https://github.com/asyncapi/spec/issues/554

**Related PR(s):**
https://github.com/asyncapi/asyncapi-node/pull/63 - fix bug with true/false schemas in JSON Schema of spec
https://github.com/asyncapi/parser-js/pull/311 - handle true/false JSON Schema in parser 
https://github.com/asyncapi/asyncapi-react/pull/367 - handle Boolean JSON Schema in the `react-component` 

---

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->