### PR TITLE
fix: clarify support for Boolean JSON Schemas

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1509,8 +1509,7 @@ components:
 #### <a name="schemaObject"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
-These types can be objects, but also primitives and arrays.
-This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/).
+These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/). The empty schema (which allows any instance to validate) MAY be represented by the `boolean` value `true` and a schema which allows no instance to validate MAY be represented by the `boolean` value `false`.
 
 Further information about the properties can be found in [JSON Schema Core](https://tools.ietf.org/html/draft-handrews-json-schema-01) and [JSON Schema Validation](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01).
 Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here.
@@ -1716,6 +1715,30 @@ required:
 example:
   name: Puma
   id: 1
+```
+
+###### Model with Boolean Schemas
+
+```json
+{
+  "type": "object",
+  "required": [
+    "anySchema"
+  ],
+  "properties": {
+    "anySchema": true,
+    "cannotBeDefined": false
+  }
+}
+```
+
+```yaml
+type: object
+required:
+- anySchema
+properties:
+  anySchema: true
+  cannotBeDefined: false
 ```
 
 ###### Models with Composition


### PR DESCRIPTION
---
title: "Mention about true/false JSON Schemas in Schema Object"
---

As Schema Object in spec is defined as superset of the [JSON Schema Specification Draft 07](http://json-schema.org/), it would be nice to specify that the Schema Object itself can be boolean value. I know it results from the definition of draft 07, so I'd like to hear your opinion about the changes.

Description for `true/false` schemas I took from https://github.com/OAI/OpenAPI-Specification/pull/2609/files Thanks to @MikeRalphson 

> NOTE: PR is a copy of https://github.com/asyncapi/spec/pull/550 but with changed base branch from `master` to `2021-06-release` - remote git see other revisions than I have in local and tries to interpolate the commits from `master` branch 

---

**Related issue(s):**
https://github.com/asyncapi/parser-js/issues/232
Fixes https://github.com/asyncapi/spec/issues/554

**Related PR(s):**
https://github.com/asyncapi/asyncapi-node/pull/63 - fix bug with true/false schemas in JSON Schema of spec
https://github.com/asyncapi/parser-js/pull/311 - handle true/false JSON Schema in parser 
https://github.com/asyncapi/asyncapi-react/pull/367 - handle Boolean JSON Schema in the `react-component` 

---

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->