### PR TITLE
chore: update topic names in Kafka example

### DIFF
--- a/examples/streetlights-kafka.yml
+++ b/examples/streetlights-kafka.yml
@@ -25,7 +25,7 @@ servers:
 defaultContentType: application/json
 
 channels:
-  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+  smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured:
     description: The topic on which measured values may be produced and consumed.
     parameters:
       streetlightId:
@@ -38,7 +38,7 @@ channels:
       message:
         $ref: '#/components/messages/lightMeasured'
 
-  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.on:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
@@ -49,7 +49,7 @@ channels:
       message:
         $ref: '#/components/messages/turnOnOff'
 
-  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.off:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'
@@ -60,7 +60,7 @@ channels:
       message:
         $ref: '#/components/messages/turnOnOff'
 
-  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
+  smartylighting.streetlights.1.0.action.{streetlightId}.dim:
     parameters:
       streetlightId:
         $ref: '#/components/parameters/streetlightId'


### PR DESCRIPTION
Update the Kafka streetlights example so that it uses channel
names that use characters that are valid for use in Kafka topic
names.

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>