### PR TITLE
chore: remove `a` tags from spec headings

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -80,32 +80,32 @@ It means that the [application](#definitionsApplication) allows [consumers](#def
 
 <!-- /TOC -->
 
-## <a name="definitions"></a>Definitions
+## Definitions
 
-#### <a name="definitionsApplication"></a>Application
+#### Application
 An application is any kind of computer program or a group of them. It MUST be a [producer](#definitionsProducer), a [consumer](#definitionsConsumer) or both. An application MAY be a microservice, IoT device (sensor), mainframe process, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitionsProtocol). An application MUST also use a protocol supported by the server in order to connect and exchange [messages](#definitionsMessage). 
 
-#### <a name="definitionsProducer"></a>Producer
+#### Producer
 A producer is a type of application, connected to a server, that is creating [messages](#definitionsMessage) and addressing them to [channels](#definitionsChannel). A producer MAY be publishing to multiple channels depending on the server, protocol, and use-case pattern.
 
-#### <a name="definitionsConsumer"></a>Consumer
+#### Consumer
 A consumer is a type of application, connected to a server via a supported [protocol](#definitionsProtocol), that is consuming [messages](#definitionsMessage) from [channels](#definitionsChannel). A consumer MAY be consuming from multiple channels depending on the server, protocol, and the use-case pattern.
 
-#### <a name="definitionsMessage"></a>Message
+#### Message
 A message is the mechanism by which information is exchanged via a channel between servers and applications. A message MUST contain a payload and MAY also contain headers. The headers MAY be subdivided into [protocol](#definitionsProtocol)-defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response. 
 
-#### <a name="definitionsChannel"></a>Channel
+#### Channel
 A channel is an addressable component, made available by the server, for the organization of [messages](#definitionsMessage). [Producer](#definitionsProducer) applications send messages to channels and [consumer](#definitionsConsumer) applications consume messages from channels. Servers MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the server implementation, the channel MAY be included in the message via protocol-defined headers.
 
-#### <a name="definitionsProtocol"></a>Protocol
+#### Protocol
 A protocol is the mechanism (wireline protocol or API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocols include, but are not limited to, AMQP, HTTP, JMS, Kafka, MQTT, STOMP, Mercure, WebSocket.  
 
-#### <a name="definitionsBindings"></a>Bindings
+#### Bindings
 A "binding" (or "protocol binding") is a mechanism to define protocol-specific information. Therefore, a protocol binding MUST define protocol-specific information only. 
 
-## <a name="specification"></a>Specification
+## Specification
 
-### <a name="format"></a>Format
+### Format
 
 The files describing the message-driven API in accordance with the AsyncAPI Specification are represented as JSON objects and conform to the JSON standards.
 YAML, being a superset of JSON, can be used as well to represent a A2S (AsyncAPI Specification) file.
@@ -139,9 +139,9 @@ This is applicable for `$ref` fields in the specification as follows from the [J
 
 By convention, the AsyncAPI Specification (A2S) file is named `asyncapi.json` or `asyncapi.yaml`.
 
-### <a name="schema"></a>Schema
+### Schema
 
-#### <a name="A2SObject"></a>AsyncAPI Object
+#### AsyncAPI Object
 
 This is the root document object for the API specification.
 It combines resource listing and API declaration together into one document.
@@ -163,7 +163,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-#### <a name="A2SVersionString"></a>AsyncAPI Version String
+#### AsyncAPI Version String
 
 The version string signifies the version of the AsyncAPI Specification that the document complies to.
 The format for this string _must_ be `major`.`minor`.`patch`.  The `patch` _may_ be suffixed by a hyphen and extra alphanumeric characters.
@@ -173,7 +173,7 @@ The patch version will not be considered by tooling, making no distinction betwe
 
 In subsequent versions of the AsyncAPI Specification, care will be given such that increments of the `minor` version should not interfere with operations of tooling developed to a lower minor version. Thus a hypothetical `1.1.0` specification should be usable with tooling designed for `1.0.0`.
 
-#### <a name="A2SIdString"></a>Identifier
+#### Identifier
 
 This field represents a unique universal identifier of the [application](#definitionsApplication) the AsyncAPI document is defining. It must conform to the URI format, according to [RFC3986](http://tools.ietf.org/html/rfc3986).
 
@@ -201,7 +201,7 @@ id: 'urn:com:smartylighting:streetlights:server'
 id: 'https://github.com/smartylighting/streetlights-server'
 ```
 
-#### <a name="infoObject"></a>Info Object
+#### Info Object
 
 The object provides metadata about the API.
 The metadata can be used by the clients if needed.
@@ -253,7 +253,7 @@ license:
 version: 1.0.1
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### Contact Object
 
 Contact information for the exposed API.
 
@@ -283,7 +283,7 @@ url: http://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### License Object
 
 License information for the exposed API.
 
@@ -310,7 +310,7 @@ name: Apache 2.0
 url: http://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serversObject"></a>Servers Object
+#### Servers Object
 
 The Servers Object is a map of [Server Objects](#serverObject).
 
@@ -342,7 +342,7 @@ production:
 ```
 
 
-#### <a name="serverObject"></a>Server Object
+#### Server Object
 
 An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data. This object is used to capture details such as URIs, protocols and security configuration. Variable substitution can be used so that some details, for example usernames and passwords, can be injected by code generation tools.
 
@@ -472,7 +472,7 @@ servers:
 ```
 
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -491,7 +491,7 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="defaultContentTypeString"></a>Default Content Type
+#### Default Content Type
 
 A string representing the default content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). This value MUST be used by schema parsers when the [contentType](#messageObjectContentType) property is omitted.
 
@@ -514,7 +514,7 @@ defaultContentType: application/json
 
 
 
-#### <a name="channelsObject"></a>Channels Object
+#### Channels Object
 
 Holds the relative paths to the individual channel and their operations. Channel paths are relative to servers.
 
@@ -547,7 +547,7 @@ user/signedup:
 
 
 
-#### <a name="channelItemObject"></a>Channel Item Object
+#### Channel Item Object
 
 Describes the operations available on a single channel.
 
@@ -645,7 +645,7 @@ subscribe:
 
 
 
-#### <a name="operationObject"></a>Operation Object
+#### Operation Object
 
 Describes a publish or a subscribe operation. This provides a place to document how and why messages are sent and received.
 
@@ -743,7 +743,7 @@ traits:
 
 
 
-#### <a name="operationTraitObject"></a>Operation Trait Object
+#### Operation Trait Object
 
 Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except `message` and `traits`.
 
@@ -783,7 +783,7 @@ bindings:
 
 
 
-#### <a name="parametersObject"></a>Parameters Object
+#### Parameters Object
 
 Describes a map of parameters included in a channel name.
 
@@ -830,7 +830,7 @@ user/{userId}/signup:
 
 
 
-#### <a name="parameterObject"></a>Parameter Object
+#### Parameter Object
 
 Describes a parameter included in a channel name.
 
@@ -880,7 +880,7 @@ user/{userId}/signup:
 
 
 
-#### <a name="serverBindingsObject"></a>Server Bindings Object
+#### Server Bindings Object
 
 Map describing protocol-specific definitions for a server.
 
@@ -908,7 +908,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="channelBindingsObject"></a>Channel Bindings Object
+#### Channel Bindings Object
 
 Map describing protocol-specific definitions for a channel.
 
@@ -936,7 +936,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="operationBindingsObject"></a>Operation Bindings Object
+#### Operation Bindings Object
 
 Map describing protocol-specific definitions for an operation.
 
@@ -964,7 +964,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="messageBindingsObject"></a>Message Bindings Object
+#### Message Bindings Object
 
 Map describing protocol-specific definitions for a message.
 
@@ -996,7 +996,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
 
 
 
-#### <a name="messageObject"></a>Message Object
+#### Message Object
 
 Describes a message received on a given channel and operation.
 
@@ -1021,7 +1021,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-##### <a name="messageObjectSchemaFormatTable"></a>Schema formats table
+##### Schema formats table
 
 The following table contains a set of values that every implementation MUST support.
 
@@ -1185,7 +1185,7 @@ payload:
 
 
 
-#### <a name="messageTraitObject"></a>Message Trait Object
+#### Message Trait Object
 
 Describes a trait that MAY be applied to a [Message Object](#messageObject). This object MAY contain any property from the [Message Object](#messageObject), except `payload` and `traits`.
 
@@ -1224,11 +1224,11 @@ schemaFormat: 'application/vnd.apache.avro+yaml;version=1.9.0'
 contentType: application/json
 ```
 
-#### <a name="tagsObject"></a>Tags Object
+#### Tags Object
 
 A Tags object is a list of Tag Objects.
 
-#### <a name="tagObject"></a>Tag Object
+#### Tag Object
 
 Allows adding meta data to a single tag.
 
@@ -1261,7 +1261,7 @@ description: User-related messages
 
 
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -1288,7 +1288,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="referenceObject"></a>Reference Object
+#### Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
@@ -1316,7 +1316,7 @@ This object cannot be extended with additional properties and any properties add
   $ref: '#/components/schemas/Pet'
 ```
 
-#### <a name="componentsObject"></a>Components Object
+#### Components Object
 
 Holds a set of reusable objects for different aspects of the AsyncAPI specification.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -1507,7 +1507,7 @@ components:
             maximum: 100
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 07](http://json-schema.org/). The empty schema (which allows any instance to validate) MAY be represented by the `boolean` value `true` and a schema which allows no instance to validate MAY be represented by the `boolean` value `false`.
@@ -1572,7 +1572,7 @@ Field Name | Type | Description
 
 This object can be extended with [Specification Extensions](#specificationExtensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### Composition and Inheritance (Polymorphism)
 
 The AsyncAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
 `allOf` takes in an array of object definitions that are validated *independently* but together compose a single object.
@@ -1973,7 +1973,7 @@ schemas:
 
 
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### Security Scheme Object
 
 Defines a security scheme that can be used by the operations. Supported schemes are:
 
@@ -2138,7 +2138,7 @@ flows:
 type: scramSha512
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
@@ -2152,7 +2152,7 @@ Field Name | Type | Description
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -2207,7 +2207,7 @@ flows:
       read:pets: read your pets
 ```
 
-#### <a name="securityRequirementObject"></a>Security Requirement Object
+#### Security Requirement Object
 
 Lists the required security schemes to execute this operation.
 The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](#componentsSecuritySchemes) under the [Components Object](#componentsObject).
@@ -2263,7 +2263,7 @@ petstore_auth:
 - read:pets
 ```
 
-### <a name="correlationIdObject"></a>Correlation ID Object
+### Correlation ID Object
 
 An object that specifies an identifier at design time that can used for message tracing and correlation. 
 
@@ -2292,7 +2292,7 @@ description: Default Correlation ID
 location: $message.header#/correlationId
 ```
 
-### <a name="runtimeExpression"></a>Runtime Expression
+### Runtime Expression
 
 A runtime expression allows values to be defined based on information that will be available within the message.
 This mechanism is used by [Correlation ID Object](#correlationIdObject).
@@ -2309,7 +2309,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-##### <a name="runtimeExpressionExamples"></a>Examples
+##### Examples
 
 Source Location | Example expression  | Notes
 ---|:---|:---|
@@ -2318,7 +2318,7 @@ Message Payload Property | `$message.payload#/messageId` | Correlation ID is set
 
 Runtime expressions preserve the type of the referenced value.
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### Specification Extensions
 
 While the AsyncAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -2330,7 +2330,7 @@ Field Pattern | Type | Description
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="dataTypeFormat"></a>Data Type Formats
+### Data Type Formats
 
 Primitives have an optional modifier property: `format`.
 The AsyncAPI specification uses several known formats to more finely define the data type being used.


### PR DESCRIPTION
title: "Remove all the `a` tags from headings"
---