### PR TITLE
ci: add step to remove toc from spec in action

### DIFF
--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -71,6 +71,29 @@ jobs:
             }
             const specWithoutHeading = specFile.slice(startingIndex + headingLine.length);
             fs.writeFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`, specWithoutHeading);
+      - name: Remove Table of Contents from Spec
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+
+            const startingLine = "## Table of Contents\n";
+            const endingLine = "<!-- /TOC -->\n";
+
+            const specFile = fs.readFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`);
+
+            const startingIndex = specFile.indexOf(startingLine);
+            const endingIndex = specFile.indexOf(endingLine);
+
+            if (startingIndex === -1 || endingIndex === -1) {
+              console.log("TOC not found");
+              return;
+            }
+            const firstHalf = specFile.slice(0, startingIndex);
+            const secondHalf = specFile.slice(endingIndex + endingLine.length);
+            const specWithoutToc = `${firstHalf}${secondHalf}`;
+            fs.writeFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`, specWithoutToc);
       - name: Change the redirect file to point to latest spec
         uses: actions/github-script@v3
         if: ${{github.event.release.prerelease == false}}


### PR DESCRIPTION
---
title: "Add step to remove Table of Contents from Spec file"
---

The spec file contains `Table Of Contents`, which would be good to strip out from the website. This action step will remove the TOC from the spec file.

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->