### PR TITLE
chore: delete step that removes the `# AsyncAPI Specification` heading

### DIFF
--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -52,25 +52,6 @@ jobs:
         working-directory: ./website
         run: |
           cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{github.event.release.tag_name}}.md
-      - name: Remove `# AsyncAPI Specification` line
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const fs = require("fs");
-
-            const headingLine = "# AsyncAPI Specification\n";
-
-            const specFile = fs.readFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`);
-
-            const startingIndex = specFile.indexOf(headingLine);
-
-            if (startingIndex === -1) {
-              console.log("Heading not found");
-              return;
-            }
-            const specWithoutHeading = specFile.slice(startingIndex + headingLine.length);
-            fs.writeFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`, specWithoutHeading);
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v3
         with:


### PR DESCRIPTION
---
title: "delete step that removes the `# AsyncAPI Specification` heading"
---

Now that the presence of `# AsyncAPI Specification` in the spec file does not break the website(ref: https://github.com/asyncapi/website/pull/287), it's safe to remove the step which removes that heading.

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->