### PR TITLE
ci: add workflow for updating latest spec doc in the website

### DIFF
--- a/.github/scripts/remove-toc.js
+++ b/.github/scripts/remove-toc.js
@@ -1,0 +1,25 @@
+/**
+ * Remove TOC from the given specification in the website repo
+ *
+ * @param {string} givenSpec 
+ */
+module.exports = (givenSpec) => {
+  const fs = require("fs");
+
+  const startingLine = "## Table of Contents\n";
+  const endingLine = "<!-- /TOC -->\n";
+
+  const specFile = fs.readFileSync(`./website/pages/docs/specifications/${givenSpec}.md`);
+
+  const startingIndex = specFile.indexOf(startingLine);
+  const endingIndex = specFile.indexOf(endingLine);
+
+  if (startingIndex === -1 || endingIndex === -1) {
+    console.log("TOC not found");
+    return;
+  }
+  const firstHalf = specFile.slice(0, startingIndex);
+  const secondHalf = specFile.slice(endingIndex + endingLine.length);
+  const specWithoutToc = `${firstHalf}${secondHalf}`;
+  fs.writeFileSync(`./website/pages/docs/specifications/${givenSpec}.md`, specWithoutToc);
+}

--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -1,4 +1,4 @@
-name: Update spec document because of new spec release
+name: Push new spec to the website because of new spec release
 
 on:
   release:

--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -56,25 +56,10 @@ jobs:
         uses: actions/github-script@v3
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
+          # require needs relative path to the script (relative to the current working directory)
           script: |
-            const fs = require("fs");
-
-            const startingLine = "## Table of Contents\n";
-            const endingLine = "<!-- /TOC -->\n";
-
-            const specFile = fs.readFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`);
-
-            const startingIndex = specFile.indexOf(startingLine);
-            const endingIndex = specFile.indexOf(endingLine);
-
-            if (startingIndex === -1 || endingIndex === -1) {
-              console.log("TOC not found");
-              return;
-            }
-            const firstHalf = specFile.slice(0, startingIndex);
-            const secondHalf = specFile.slice(endingIndex + endingLine.length);
-            const specWithoutToc = `${firstHalf}${secondHalf}`;
-            fs.writeFileSync(`./website/pages/docs/specifications/${{github.event.release.tag_name}}.md`, specWithoutToc);
+            const script = require('./spec/.github/scripts/remove-toc.js');
+            script(${{github.event.release.tag_name}});
       - name: Change the redirect file to point to latest spec
         uses: actions/github-script@v3
         if: ${{github.event.release.prerelease == false}}

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Create branch
         working-directory: ./website
         run: |
-          git checkout -b update-spec
+          git checkout -b update-spec-${{ steps.latest_version.outputs.latest_tag }}
       - name: Check for previous spec file and remove it
         uses: actions/github-script@v3
         with:
@@ -91,4 +91,4 @@ jobs:
       - name: Create PR
         working-directory: ./website
         run: |
-          gh pr create --title "docs(spec): update latest specification" --body "Updated specification is available and this PR introduces update to specification document on the website" --head "update-specification"
+          gh pr create --title "docs(spec): update latest specification" --body "Updated specification is available and this PR introduces update to specification document on the website" --head "update-spec-${{ steps.latest_version.outputs.latest_tag }}"

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -1,0 +1,94 @@
+name: Update latest specification document in the website
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'spec/asyncapi.md'
+
+jobs:
+  Make-PR:
+    name: Make PR on website repository with updated latest spec
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - name: Checkout Current repository
+        uses: actions/checkout@v2
+        with:
+          path: spec
+          ref: ${{ github.event.release.target_commitish }}
+      - name: Checkout Another repository
+        uses: actions/checkout@v2
+        with:
+          repository: asyncapi/website
+          path: website
+          token: ${{ env.GITHUB_TOKEN }}
+      - name: Config git
+        run: |
+          git config --global user.name asyncapi-bot
+          git config --global user.email info@asyncapi.io
+      - name: Get latest release
+        id: latest_version
+        uses: abatilo/release-info-action@v1.3.0
+        with:
+          owner: asyncapi
+          repo: spec
+      - name: Create branch
+        working-directory: ./website
+        run: |
+          git checkout -b update-spec
+      - name: Check for previous spec file and remove it
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+
+            const specFiles = fs.readdirSync("./website/pages/docs/specifications");
+
+            const latestRelease = `${{ steps.latest_version.outputs.latest_tag }}`;
+
+            for (const filename of specFiles) {
+              if (filename.startsWith(latestRelease)) {
+                fs.unlinkSync(`./website/pages/docs/specifications/${filename}`);
+              }
+            }
+      - name: Copy Spec file from Current Repo to Another
+        working-directory: ./website
+        run: |
+          cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md
+      - name: Remove Table of Contents from Spec
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+
+            const startingLine = "## Table of Contents\n";
+            const endingLine = "<!-- /TOC -->\n";
+
+            const specFile = fs.readFileSync(`./website/pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md`);
+
+            const startingIndex = specFile.indexOf(startingLine);
+            const endingIndex = specFile.indexOf(endingLine);
+
+            if (startingIndex === -1 || endingIndex === -1) {
+              console.log("TOC not found");
+              return;
+            }
+            const firstHalf = specFile.slice(0, startingIndex);
+            const secondHalf = specFile.slice(endingIndex + endingLine.length);
+            const specWithoutToc = `${firstHalf}${secondHalf}`;
+            fs.writeFileSync(`./website/pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md`, specWithoutToc);
+      - name: Commit and push
+        working-directory: ./website
+        run: |
+          git add .
+          git commit -m "docs(spec): update latest specification"
+          git push https://${{ env.GITHUB_TOKEN }}@github.com/asyncapi/website
+      - name: Create PR
+        working-directory: ./website
+        run: |
+          gh pr create --title "docs(spec): update latest specification" --body "Updated specification is available and this PR introduces update to specification document on the website" --head "update-specification"

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -39,22 +39,6 @@ jobs:
         working-directory: ./website
         run: |
           git checkout -b update-spec-${{ steps.latest_version.outputs.latest_tag }}
-      - name: Check for previous spec file and remove it
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-          script: |
-            const fs = require("fs");
-
-            const specFiles = fs.readdirSync("./website/pages/docs/specifications");
-
-            const latestRelease = `${{ steps.latest_version.outputs.latest_tag }}`;
-
-            for (const filename of specFiles) {
-              if (filename.startsWith(latestRelease)) {
-                fs.unlinkSync(`./website/pages/docs/specifications/${filename}`);
-              }
-            }
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
@@ -63,25 +47,10 @@ jobs:
         uses: actions/github-script@v3
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
+          # require needs relative path to the script (relative to the current working directory)
           script: |
-            const fs = require("fs");
-
-            const startingLine = "## Table of Contents\n";
-            const endingLine = "<!-- /TOC -->\n";
-
-            const specFile = fs.readFileSync(`./website/pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md`);
-
-            const startingIndex = specFile.indexOf(startingLine);
-            const endingIndex = specFile.indexOf(endingLine);
-
-            if (startingIndex === -1 || endingIndex === -1) {
-              console.log("TOC not found");
-              return;
-            }
-            const firstHalf = specFile.slice(0, startingIndex);
-            const secondHalf = specFile.slice(endingIndex + endingLine.length);
-            const specWithoutToc = `${firstHalf}${secondHalf}`;
-            fs.writeFileSync(`./website/pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md`, specWithoutToc);
+            const script = require('./spec/.github/scripts/remove-toc.js');
+            script(${{ steps.latest_version.outputs.latest_tag }});
       - name: Commit and push
         working-directory: ./website
         run: |

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: spec
-          ref: ${{ github.event.release.target_commitish }}
       - name: Checkout Another repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Add `update-spec.yaml` workflow which will push changes of spec from master branch to the website repo.

Related PR(s)
https://github.com/asyncapi/spec/pull/589