### PR TITLE
docs: remove trailing commas from examples

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1358,90 +1358,92 @@ my.org.User
 ##### Components Object Example
 
 ```json
-"components": {
-  "schemas": {
-    "Category": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    },
-    "Tag": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "name": {
-          "type": "string"
-        }
-      }
-    }
-  },
-  "messages": {
-    "userSignUp": {
-      "summary": "Action to sign a user up.",
-      "description": "Multiline description of what this action does.\nHere you have another line.\n",
-      "tags": [
-        {
-          "name": "user"
-        },
-        {
-          "name": "signup"
-        }
-      ],
-      "headers": {
+{
+  "components": {
+    "schemas": {
+      "Category": {
         "type": "object",
         "properties": {
-          "applicationInstanceId": {
-            "description": "Unique identifier for a given instance of the publishing application",
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
             "type": "string"
           }
         }
       },
-      "payload": {
+      "Tag": {
         "type": "object",
         "properties": {
-          "user": {
-            "$ref": "#/components/schemas/userCreate"
+          "id": {
+            "type": "integer",
+            "format": "int64"
           },
-          "signup": {
-            "$ref": "#/components/schemas/signup"
+          "name": {
+            "type": "string"
           }
         }
       }
-    }
-  },
-  "parameters": {
-    "userId": {
-      "description": "Id of the user.",
-      "schema": {
-        "type": "string"
+    },
+    "messages": {
+      "userSignUp": {
+        "summary": "Action to sign a user up.",
+        "description": "Multiline description of what this action does.\nHere you have another line.\n",
+        "tags": [
+          {
+            "name": "user"
+          },
+          {
+            "name": "signup"
+          }
+        ],
+        "headers": {
+          "type": "object",
+          "properties": {
+            "applicationInstanceId": {
+              "description": "Unique identifier for a given instance of the publishing application",
+              "type": "string"
+            }
+          }
+        },
+        "payload": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "$ref": "#/components/schemas/userCreate"
+            },
+            "signup": {
+              "$ref": "#/components/schemas/signup"
+            }
+          }
+        }
       }
-    }
-  },
-  "correlationIds": {
-    "default": {
-      "description": "Default Correlation ID",
-      "location": "$message.header#/correlationId"
-    }
-  },
-  "messageTraits": {
-    "commonHeaders": {
-      "headers": {
-        "type": "object",
-        "properties": {
-          "my-app-header": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
+    },
+    "parameters": {
+      "userId": {
+        "description": "Id of the user.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "correlationIds": {
+      "default": {
+        "description": "Default Correlation ID",
+        "location": "$message.header#/correlationId"
+      }
+    },
+    "messageTraits": {
+      "commonHeaders": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "my-app-header": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            }
           }
         }
       }

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -703,7 +703,7 @@ This object can be extended with [Specification Extensions](#specificationExtens
   "bindings": {
     "amqp": {
       "ack": false
-    },
+    }
   },
   "traits": [
     { "$ref": "#/components/operationTraits/kafka" }
@@ -1897,7 +1897,7 @@ schemas:
               "const": "StickBug"
             },
             "color": {
-              "type": "string",
+              "type": "string"
             }
           },
           "required": [
@@ -2093,7 +2093,7 @@ in: header
 {
   "type": "http",
   "scheme": "bearer",
-  "bearerFormat": "JWT",
+  "bearerFormat": "JWT"
 }
 ```
 


### PR DESCRIPTION
Per documentation https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

JSON specification does not allow trailing commas

On related note the [Components Object Example (JSON)](https://github.com/asyncapi/spec/blob/v2.1.0/spec/asyncapi.md#components-object-example) is ambiguous, because as it currently is, it is not valid JSON object but only part of the object.
Where we have 2 possible resolutions
  1. Remove the `"components": ` part to show only the object containing the "Components Object"
  2. Wrap the example in another object, possibly just add the opening and closing curly brackets.
  
All other JSON objects currently in spec are valid afaict