### PR TITLE
feat: allow to define Schema Object in Server variables

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -437,15 +437,20 @@ The following shows how variables can be used for a server configuration:
       "protocol": "secure-mqtt",
       "variables": {
         "username": {
-          "default": "demo",
-          "description": "This value is assigned by the service provider, in this example `gigantic-server.com`"
+          "description": "This value is assigned by the service provider, in this example `gigantic-server.com`",
+          "schema": {
+            "type": "string",
+            "default": "demo"
+          }
         },
         "port": {
-          "enum": [
-            "8883",
-            "8884"
-          ],
-          "default": "8883"
+          "schema": {
+            "enum": [
+              "8883",
+              "8884"
+            ],
+            "default": "8883"
+          }
         }
       }
     }
@@ -461,14 +466,16 @@ servers:
     protocol: secure-mqtt
     variables:
       username:
-        # note! no enum here means it is an open value
-        default: demo
         description: This value is assigned by the service provider, in this example `gigantic-server.com`
+        schema:
+          type: string
+          default: demo
       port:
-        enum:
-          - '8883'
-          - '8884'
-        default: '8883'
+        schema:
+          enum:
+            - '8883'
+            - '8884'
+          default: '8883'
 ```
 
 
@@ -480,10 +487,8 @@ An object representing a Server Variable for server URL template substitution.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="serverVariableObjectEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="serverVariableObjectDefault"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
 <a name="serverVariableObjectDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariableObjectExamples"></a>examples | [`string`] | An array of examples of the server variable.
+<a name="serverVariableObjectSchema"></a>schema | [Schema Object](#schemaObject) \| [Reference Object](#referenceObject) | Definition of the server variable.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 


### PR DESCRIPTION
---
title: "Allow to define Schema Object in Server variables"
---

---

**Related issue(s):**
https://github.com/asyncapi/spec/issues/583

---

As I described in the https://github.com/asyncapi/spec/issues/583 issue, I'm wondering why we have inconsistencies for schemas in `server.variables` and `channel.parameters`. This PR introduces change of shape of single Server Variable Object:

- instead of having the 3 words `enum`, `default`, `examples`, which work identically to the JSON Schema keywords, we will now have the word `schema`, which is Schema Object
- `description` is still available, to be consistent with Channel Parameter Object. 
- we can remove `description` field (it is also defined in Schema Object) and flat the `schema` so definition of single variable can have shape like:

  ```yaml
  variables:
    username:
      type: string
      description: This value is assigned by the service provider, in this example `gigantic-server.com`
      default: demo
  ```

- another solution is to add the possibility to define other keywords like `format`, `pattern`, `minLength` etc and for numeric values (integer and number types), but in the current proposal someone can define a schema for server variable in `components/schemas` and we are reusing things that already exist in spec, not creating something from scratch. 
- with current proposal, in the future, when we will implement and resolve problems (https://github.com/asyncapi/spec/issues/528 https://github.com/asyncapi/spec/issues/216), user will be able to define variables in different formats than JSON Schema.

Comments are more than welcome!

BTW. It's a breaking change, so it should be (hopefully) merged in the `3.0.0`.