### PR TITLE
docs(spec): added name proposal to channel item object

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -562,6 +562,7 @@ Describes the operations available on a single channel.
 Field Name | Type | Description
 ---|:---:|---
 <a name="channelItemObjectRef"></a>$ref | `string` | Allows for an external definition of this channel item. The referenced structure MUST be in the format of a [Channel Item Object](#channelItemObject). If there are conflicts between the referenced definition and this Channel Item's definition, the behavior is *undefined*.
+<a name="channelItemObjectName"></a>name | `string` | Associates a name to the channel. This can help tooling for code generation.
 <a name="channelItemObjectDescription"></a>description | `string` | An optional description of this channel item. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
 <a name="channelItemObjectSubscribe"></a>subscribe | [Operation Object](#operationObject) | A definition of the SUBSCRIBE operation, which defines the messages produced by the application and sent to the channel.
 <a name="channelItemObjectPublish"></a>publish | [Operation Object](#operationObject) | A definition of the PUBLISH operation, which defines the messages consumed by the application from the channel.


### PR DESCRIPTION
---
title: "Nameable Channel Item Object"
---

---

**Related issue(s):**

#614
---

This proposal adds an optional name field to the Channel Item Object type. I'm trying to generate WebSocket code using AsyncAPI document. Subscribe and publish operations are nameable/identifiable using operationId, but that's not how sockets work, as a single channel is capable for both. It makes no sense to open a connection for both. 

## Example:

Let's assume we have the following schema:

```jsonc
{
  "asyncapi": "2.0",
  "info": {
    "title": "",
    "version": ""
  },
  "components": {
    "schemas": {
      "NamedSimpleObject": {
        "type": "object",
        "required": [
          "stringProperty",
        ],
        "properties": {
          "stringProperty": {
            "type": "string"
          }
        }
      }
  },
  "channels": {
    "/test/{pathParam}": {
      "name": "TestChannel",
      "parameters": {
        "pathParam": {
          "description": "test param",
          "schema": {
            "type": "string"
          }
        }
      },
      "subscribe": {
        "operationId": "subToTest",
        "summary": "Sub to test",
        "message": {
          "payload": {
            "$ref": "#/components/schemas/NamedSimpleObject"
          }
        }
      },
      "publish": {
        "operationId": "pubToTest",
        "summary": "Pub to test",
        "message": {
          "payload": {
            "$ref": "#/components/schemas/NamedSimpleObject"
          }
        }
      }
    }
  }
}
```

This could be translated roughly to something like this in code

```ts
// Name based on my proposal
class TestChannel {
  private socket: WebSocket
  
  // Parameter from the channels ParameterObject
  constructor(pathParam: string) {
    this.socket = new WebSocket(`/test/${pathParam}`)
  }

  // subToTest is the operationId, NamedSimpleObject the message's schema, all good here
  subToTest(listener: (data: NamedSimpleObject) => void): void {
    this.socket.addEventListener('message', ({ data }) => {
      listener(JSON.parse(data))
    })
  }
  
  // pubToTest is the operationId, NamedSimpleObject the message's schema, all good here too
  pubToTest(data: NamedSimpleObject): void {
    this.socket.send(JSON.stringify(data))
  }
}
```

As you can see without the `name` field, it's not possible to name whatever concept generated code is using to encapsulate both subscribe and publish. It could be `channelId` too in case it needs to be inline with the `operationId`.