### PR TITLE
feat: update points from 2.1.0 version to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@
 
 The latest draft specification can be found at [spec/asyncapi.md](./spec/asyncapi.md) which tracks the latest commit to the master branch in this repository.
 
-* [Version 2.1.0](https://github.com/asyncapi/spec/blob/v2.1.0/spec/asyncapi.md) (latest)
+* [Version 2.2.0](https://github.com/asyncapi/spec/blob/v2.2.0/spec/asyncapi.md) (latest)
+* [Version 2.1.0](https://github.com/asyncapi/spec/blob/v2.1.0/spec/asyncapi.md)
 * [Version 2.0.0](https://github.com/asyncapi/spec/blob/2.0.0/versions/2.0.0/asyncapi.md)
 * [Version 1.2.0](https://github.com/asyncapi/spec/blob/1.2.0/README.md) (deprecated)
 * [Version 1.1.0](https://github.com/asyncapi/spec/blob/1.1.0/README.md) (deprecated)

--- a/examples/anyof.yml
+++ b/examples/anyof.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: AnyOf example
   version: '1.0.0'

--- a/examples/application-headers.yml
+++ b/examples/application-headers.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Application Headers example
   version: '1.0.0'

--- a/examples/correlation-id.yml
+++ b/examples/correlation-id.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Correlation ID Example
   version: '1.0.0'

--- a/examples/gitter-streaming.yml
+++ b/examples/gitter-streaming.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 id: 'urn:com:gitter:streaming:api'
 info:
   title: Gitter Streaming API

--- a/examples/mercure.yml
+++ b/examples/mercure.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Mercure Hub Example
   version: '1.0.0'

--- a/examples/not.yml
+++ b/examples/not.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Not example
   version: '1.0.0'

--- a/examples/oneof.yml
+++ b/examples/oneof.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: OneOf example
   version: '1.0.0'

--- a/examples/rpc-client.yml
+++ b/examples/rpc-client.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 id: 'urn:rpc:example:client'
 defaultContentType: application/json
 

--- a/examples/rpc-server.yml
+++ b/examples/rpc-server.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 id: 'urn:rpc:example:server'
 defaultContentType: application/json
 

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Account Service
   version: 1.0.0

--- a/examples/slack-rtm.yml
+++ b/examples/slack-rtm.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 id: 'urn:com:slack:rtm:api'
 info:
   title: Slack Real Time Messaging API

--- a/examples/streetlights-kafka.yml
+++ b/examples/streetlights-kafka.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Streetlights Kafka API
   version: '1.0.0'

--- a/examples/streetlights-mqtt.yml
+++ b/examples/streetlights-mqtt.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 info:
   title: Streetlights MQTT API
   version: '1.0.0'

--- a/examples/websocket-gemini.yml
+++ b/examples/websocket-gemini.yml
@@ -12,7 +12,7 @@
 # - Live stream about topics mentioned in part 1 and 2 articles: https://www.youtube.com/watch?v=8tFBcf31e_c
 #
 
-asyncapi: '2.1.0'
+asyncapi: '2.2.0'
 
 #
 # Overal information for users of the application

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -4,7 +4,7 @@
 
 Part of this content has been taken from the great work done by the folks at the [OpenAPI Initiative](https://openapis.org). Mainly because **it's a great work** and we want to keep as much compatibility as possible with the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification).
 
-#### Version 2.1.0
+#### Version 2.2.0
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
@@ -1037,7 +1037,7 @@ The following table contains a set of values that every implementation MUST supp
 
 Name | Allowed values | Notes
 ---|:---:|---
-[AsyncAPI 2.1.0 Schema Object](#schemaObject) | `application/vnd.aai.asyncapi;version=2.1.0`, `application/vnd.aai.asyncapi+json;version=2.1.0`, `application/vnd.aai.asyncapi+yaml;version=2.1.0` | This is the default when a `schemaFormat` is not provided.
+[AsyncAPI 2.2.0 Schema Object](#schemaObject) | `application/vnd.aai.asyncapi;version=2.2.0`, `application/vnd.aai.asyncapi+json;version=2.2.0`, `application/vnd.aai.asyncapi+yaml;version=2.2.0` | This is the default when a `schemaFormat` is not provided.
 [JSON Schema Draft 07](https://json-schema.org/specification-links.html#draft-7) | `application/schema+json;version=draft-07`, `application/schema+yaml;version=draft-07` | 
 
 The following table contains a set of values that every implementation is RECOMMENDED to support.


### PR DESCRIPTION
Update places that point to the `2.1.0` version, like examples, AsyncAPI Schema formats, titles etc.

Part of https://github.com/asyncapi/website/pull/324