### PR TITLE
feat: allow servers and channels to be defined as components

### DIFF
--- a/examples/social-media/backend/asyncapi.yaml
+++ b/examples/social-media/backend/asyncapi.yaml
@@ -6,8 +6,7 @@ info:
 
 servers:
   websiteWebSocketServer:
-    url: ws://mycompany.com/ws
-    protocol: ws
+    $ref: '../common/servers.yaml#/websiteWebSocketServer'
   mosquitto:
     url: mqtt://test.mosquitto.org
     protocol: mqtt

--- a/examples/social-media/common/servers.yaml
+++ b/examples/social-media/common/servers.yaml
@@ -1,0 +1,3 @@
+websiteWebSocketServer:
+  url: ws://mycompany.com/ws
+  protocol: ws

--- a/examples/social-media/frontend/asyncapi.yaml
+++ b/examples/social-media/frontend/asyncapi.yaml
@@ -6,8 +6,7 @@ info:
 
 servers:
   websiteWebSocketServer:
-    url: ws://mycompany.com/ws
-    protocol: ws
+    $ref: '../common/servers.yaml#/websiteWebSocketServer'
 
 channels:
   like/comment:

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1433,6 +1433,8 @@ All objects defined within the components object will have no effect on the API 
 Field Name | Type | Description
 ---|:---|---
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
+<a name="componentsServers"></a> servers | Map[`string`, [Server Object](#serverObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Server Objects](#serverObject).
+<a name="componentsChannels"></a> channels | Map[`string`, [Channel Object](#channelItemObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Channel Objects](#channelItemObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
@@ -1485,6 +1487,23 @@ my.org.User
           },
           "name": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "servers": {
+      "development": {
+        "url": "development.gigantic-server.com",
+        "description": "Development server",
+        "protocol": "amqp",
+        "protocolVersion": "0.9.1"
+      }
+    },
+    "channels": {
+      "user/signedup": {
+        "subscribe": {
+          "message": {
+            "$ref": "#/components/messages/userSignUp"
           }
         }
       }
@@ -1574,6 +1593,17 @@ components:
           format: int64
         name:
           type: string
+  servers:
+    development:
+      url: development.gigantic-server.com
+      description: Development server
+      protocol: amqp
+      protocolVersion: 0.9.1
+  channels:
+    user/signedup:
+      subscribe:
+        message:
+          $ref: "#/components/messages/userSignUp"
   messages:
     userSignUp:
       summary: Action to sign a user up.


### PR DESCRIPTION
> Note that this PR is targeting `asyncapi:2022-01-release` branch, so merging it won't release a new version.

**Description**
This PR is part of https://github.com/asyncapi/spec/issues/660.
It allows both `servers` and `channels` to be defined as (and referenced from) components, meaning the following will be now valid:

```yaml
servers:
  production:
    $ref: '#/components/servers/myserver'
channels:
  some/events:
    $ref: '#/components/channels/myChannel'
components:
  servers:
    myserver:
      url: "http://localhost:5000/ws"
      protocol: ws
  channels:
    myChannel:
      description: "mychannel"
```

**Related issue(s)**
https://github.com/asyncapi/spec/issues/660