### PR TITLE
docs: extend example for kafka with x509 security

### DIFF
--- a/examples/streetlights-kafka.yml
+++ b/examples/streetlights-kafka.yml
@@ -21,6 +21,7 @@ servers:
     description: Test broker
     security:
       - saslScram: []
+      - certs: []
 
 defaultContentType: application/json
 
@@ -139,6 +140,9 @@ components:
     saslScram:
       type: scramSha256
       description: Provide your username and password for SASL/SCRAM authentication
+    certs:
+      type: X509
+      description: Download the certificate files from service provider
 
   parameters:
     streetlightId:


### PR DESCRIPTION
this is driven by https://github.com/asyncapi/nodejs-template/pull/103/files PR where I had to add customized asyncapi file just with one tiny change, could be better to extend official example and use it in test instead of custom version

I think we still have this unwritten rule that best if templates work with official examples, if only possible