### PR TITLE
chore: fix codeowners file to enable people to also decide and not just bot :smile:

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,5 @@
 # The last matching pattern has the most precedence.
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
-# The default owners
-* @github-actions[bot]
-
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-/spec/asyncapi.md @fmvilas @derberg
+* @fmvilas @derberg @github-actions[bot]


### PR DESCRIPTION
I have to admit that my initial CODEOWNER configuration was not the best, like future-proof, especially now for the permissions cleanup