### PR TITLE
fix: channels type at component level is now the right one

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1438,7 +1438,7 @@ Field Name | Type | Description
 ---|:---|---
 <a name="componentsSchemas"></a> schemas | Map[`string`, [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Objects](#schemaObject).
 <a name="componentsServers"></a> servers | Map[`string`, [Server Object](#serverObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Server Objects](#serverObject).
-<a name="componentsChannels"></a> channels | Map[`string`, [Channel Object](#channelItemObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Channel Objects](#channelItemObject).
+<a name="componentsChannels"></a> channels | Map[`string`, [Channel Item Object](#channelItemObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Channel Item Objects](#channelItemObject).
 <a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
 <a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
 <a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).


### PR DESCRIPTION
Comes from https://github.com/asyncapi/spec/issues/607#issuecomment-1018318910

There was a typo on the type defined for `channels` field at components level.

**Related issue(s):**
https://github.com/asyncapi/spec/issues/607#issuecomment-1018318910

cc @jonaslagoni @dalelane @fmvilas @char0n 