### PR TITLE
chore: add 2.3.0 version to the list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@
 
 The latest draft specification can be found at [spec/asyncapi.md](./spec/asyncapi.md) which tracks the latest commit to the master branch in this repository.
 
-* [Version 2.2.0](https://github.com/asyncapi/spec/blob/v2.2.0/spec/asyncapi.md) (latest)
+* [Version 2.3.0](https://github.com/asyncapi/spec/blob/v2.3.0/spec/asyncapi.md) (latest)
+* [Version 2.2.0](https://github.com/asyncapi/spec/blob/v2.2.0/spec/asyncapi.md)
 * [Version 2.1.0](https://github.com/asyncapi/spec/blob/v2.1.0/spec/asyncapi.md)
 * [Version 2.0.0](https://github.com/asyncapi/spec/blob/2.0.0/versions/2.0.0/asyncapi.md)
 * [Version 1.2.0](https://github.com/asyncapi/spec/blob/1.2.0/README.md) (deprecated)


### PR DESCRIPTION
I've noticed that the version list in main README file is missing 2.3.0 version of the spec. This PR provides remediation.