### PR TITLE
docs: fix example typo

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -620,6 +620,7 @@ subscribe:
         user:
           $ref: "#/components/schemas/user"
         signup:
+          $ref: "#/components/schemas/signup"
 bindings:
   amqp:
     is: queue


### PR DESCRIPTION
---
title: "fix example typo"
---

Fix a typo on the "Channel Item Object Example" YAML example in the specification file.