### PR TITLE
chore: add 2022-04-release branch in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,7 @@
 ---
 branches:
 - master
-- name: 2022-01-release
+- name: 2022-04-release
   prerelease: true
 plugins:
 - - "@semantic-release/commit-analyzer"


### PR DESCRIPTION
In order to allow CI to release pre-releases for `2022-04-release`, we need to merge this into `master` branch.

Part of https://github.com/asyncapi/spec/issues/735