### PR TITLE
docs: autoupdate label step for RELEASE_PROCESS.md

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -212,6 +212,7 @@ These should be full, not draft, pull requests to allow automated tests to run.
 They should point from the [release branches](#step-3---create-release-branches) to the default/master branches for each repository.
 
 Add a **do-not-merge** label to the pull request by making a comment in the PR saying `/dnm`.
+Add a **autoupdate** label to the pull request by making a comment in the PR saying `/au`.
 
 _Note: The automation bot will keep the release branch up to date with the latest commits from the master branch (so long as there are no conflicts)._
 


### PR DESCRIPTION
Since the latest updates on the bots, the behaviour for autoupdating a branch with upstream changes has changed.
Now, it is based on the label `autoupdate`, which can be added by `/au` command. This step is crucial for the release process.