### PR TITLE
ci: updating spec urls to match new Information Architecture in website

### DIFF
--- a/.github/scripts/remove-toc.js
+++ b/.github/scripts/remove-toc.js
@@ -9,7 +9,7 @@ module.exports = (givenSpec) => {
   const startingLine = "## Table of Contents\n";
   const endingLine = "<!-- /TOC -->\n";
 
-  const specFile = fs.readFileSync(`./website/pages/docs/specifications/${givenSpec}.md`);
+  const specFile = fs.readFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`);
 
   const startingIndex = specFile.indexOf(startingLine);
   const endingIndex = specFile.indexOf(endingLine);
@@ -21,5 +21,5 @@ module.exports = (givenSpec) => {
   const firstHalf = specFile.slice(0, startingIndex);
   const secondHalf = specFile.slice(endingIndex + endingLine.length);
   const specWithoutToc = `${firstHalf}${secondHalf}`;
-  fs.writeFileSync(`./website/pages/docs/specifications/${givenSpec}.md`, specWithoutToc);
+  fs.writeFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`, specWithoutToc);
 }

--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -38,20 +38,20 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const specFiles = fs.readdirSync("./website/pages/docs/specifications");
+            const specFiles = fs.readdirSync("./website/pages/docs/reference/specification");
 
             const nextRelease = `${{github.event.release.tag_name}}`;
             const prefixRelease = nextRelease.split("-")[0];
 
             for (const filename of specFiles) {
               if (filename.startsWith(prefixRelease)) {
-                fs.unlinkSync(`./website/pages/docs/specifications/${filename}`);
+                fs.unlinkSync(`./website/pages/docs/reference/specification/${filename}`);
               }
             }
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
-          cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{github.event.release.tag_name}}.md
+          cp ../spec/spec/asyncapi.md ./pages/docs/reference/specification/${{github.event.release.tag_name}}.md
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v4
         with:
@@ -71,7 +71,7 @@ jobs:
             const endingLine = "# LATEST-SPEC-REDIRECTION:END";
 
             const releaseVersion = `${{github.event.release.tag_name}}`;
-            const redirectLine = `/docs/specifications/latest /docs/specifications/${releaseVersion} 302!\n`;
+            const redirectLine = `/docs/reference/specification/latest /docs/reference/specification/${releaseVersion} 302!\n`;
 
             const redirectFile = fs.readFileSync("./website/public/_redirects", "utf-8");
 
@@ -139,7 +139,7 @@ jobs:
 
             const releaseVersionWithoutV = releaseVersion.slice(1);
 
-            const redirectLine = `/docs/specifications/${releaseVersionWithoutV} /docs/specifications/${releaseVersion} 302!\n`;
+            const redirectLine = `/docs/reference/specification/${releaseVersionWithoutV} /docs/reference/specification/${releaseVersion} 302!\n`;
 
             const redirectFile = fs.readFileSync("./website/public/_redirects", "utf-8");
 

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
-          cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md
+          cp ../spec/spec/asyncapi.md ./pages/docs/reference/specification/${{ steps.latest_version.outputs.latest_tag }}.md
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v4
         with:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at fmvilas@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
---
title: "updating spec urls to match new Information Architecture changes via https://github.com/asyncapi/website/pull/601"
---

301 updates due to GSoD IA changes

<img width="500" src="https://user-images.githubusercontent.com/19964402/170592986-07457c70-0229-4375-8c57-3febe46261a1.png">

---

**Related issue(s):**
https://github.com/asyncapi/website/pull/601/ 

---

<!--
1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->