### PR TITLE
ci: change docs destination in the website site

### DIFF
--- a/.github/scripts/remove-toc.js
+++ b/.github/scripts/remove-toc.js
@@ -9,7 +9,7 @@ module.exports = (givenSpec) => {
   const startingLine = "## Table of Contents\n";
   const endingLine = "<!-- /TOC -->\n";
 
-  const specFile = fs.readFileSync(`./website/pages/docs/specifications/${givenSpec}.md`);
+  const specFile = fs.readFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`);
 
   const startingIndex = specFile.indexOf(startingLine);
   const endingIndex = specFile.indexOf(endingLine);
@@ -21,5 +21,5 @@ module.exports = (givenSpec) => {
   const firstHalf = specFile.slice(0, startingIndex);
   const secondHalf = specFile.slice(endingIndex + endingLine.length);
   const specWithoutToc = `${firstHalf}${secondHalf}`;
-  fs.writeFileSync(`./website/pages/docs/specifications/${givenSpec}.md`, specWithoutToc);
+  fs.writeFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`, specWithoutToc);
 }

--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -38,20 +38,20 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const specFiles = fs.readdirSync("./website/pages/docs/specifications");
+            const specFiles = fs.readdirSync("./website/pages/docs/reference/specification");
 
             const nextRelease = `${{github.event.release.tag_name}}`;
             const prefixRelease = nextRelease.split("-")[0];
 
             for (const filename of specFiles) {
               if (filename.startsWith(prefixRelease)) {
-                fs.unlinkSync(`./website/pages/docs/specifications/${filename}`);
+                fs.unlinkSync(`./website/pages/docs/reference/specification/${filename}`);
               }
             }
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
-          cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{github.event.release.tag_name}}.md
+          cp ../spec/spec/asyncapi.md ./pages/docs/reference/specification/${{github.event.release.tag_name}}.md
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v4
         with:
@@ -71,7 +71,7 @@ jobs:
             const endingLine = "# LATEST-SPEC-REDIRECTION:END";
 
             const releaseVersion = `${{github.event.release.tag_name}}`;
-            const redirectLine = `/docs/specifications/latest /docs/specifications/${releaseVersion} 302!\n`;
+            const redirectLine = `/docs/reference/specification/latest /docs/reference/specification/${releaseVersion} 302!\n`;
 
             const redirectFile = fs.readFileSync("./website/public/_redirects", "utf-8");
 
@@ -139,7 +139,7 @@ jobs:
 
             const releaseVersionWithoutV = releaseVersion.slice(1);
 
-            const redirectLine = `/docs/specifications/${releaseVersionWithoutV} /docs/specifications/${releaseVersion} 302!\n`;
+            const redirectLine = `/docs/reference/specification/${releaseVersionWithoutV} /docs/reference/specification/${releaseVersion} 302!\n`;
 
             const redirectFile = fs.readFileSync("./website/public/_redirects", "utf-8");
 

--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
-          cp ../spec/spec/asyncapi.md ./pages/docs/specifications/${{ steps.latest_version.outputs.latest_tag }}.md
+          cp ../spec/spec/asyncapi.md ./pages/docs/reference/specification/${{ steps.latest_version.outputs.latest_tag }}.md
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v4
         with:


### PR DESCRIPTION
That PR changes docs destination in the website site from `docs/specifications` to the `docs/reference/specification` - see more https://github.com/asyncapi/website/pull/601

**Related issue(s):**
Part of https://github.com/asyncapi/website/pull/601 and that PR should be merged after merging mentioned PR