### PR TITLE
docs: change invalid RFC3339 link for valid one

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -2558,6 +2558,6 @@ string | `string` | | |
 byte | `string` | `byte` | base64 encoded characters
 binary | `string` | `binary` | any sequence of octets
 boolean | `boolean` | | |
-date | `string` | `date` | As defined by `full-date` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
-dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14)
+date | `string` | `date` | As defined by `full-date` - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6)
+dateTime | `string` | `date-time` | As defined by `date-time` - [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6)
 password | `string` | `password` | Used to hint UIs the input needs to be obscured.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/193286/189415867-d226e57f-80d5-4ed9-9bf6-da74ff5232b1.png)

https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html now returns 404. This PR replaces the no longer valid link for another equivalent one: https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6

Refs #831