### PR TITLE
docs: fix incorrect spacing in the kafka streetlights example

### DIFF
--- a/examples/streetlights-kafka.yml
+++ b/examples/streetlights-kafka.yml
@@ -18,15 +18,15 @@ servers:
   scram-connections:
     url: test.mykafkacluster.org:18092
     protocol: kafka-secure
-     description: Test broker secured with scramSha256
-     security:
-       - saslScram: []
+    description: Test broker secured with scramSha256
+    security:
+      - saslScram: []
   mtls-connections:
     url: test.mykafkacluster.org:28092
     protocol: kafka-secure
-     description: Test broker secured with X509
-     security:
-       - certs: []
+    description: Test broker secured with X509
+    security:
+      - certs: []
 
 defaultContentType: application/json
 


### PR DESCRIPTION
---
YAML Formatting problem in Kafka Streetlights example
---

Title says it all. :)
