### PR TITLE
ci: fix release workflow to support release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-      - '**-release'
+      - next-spec
+      - next-major-spec
  
 jobs:
   release:


### PR DESCRIPTION
when we changed release branches, we forgot to update the workflow that reacts to them, we forgot to change the names of branches in the config

I intentionally did not make a change like `'**-spec'` to have branches named explicitly