### PR TITLE
fix: add missed IBM MQ Operation Binding

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1067,6 +1067,7 @@ Field Name | Type | Description
 <a name="operationBindingsObjectSTOMP"></a>`stomp` | [STOMP Operation Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#operation) | Protocol-specific information for a STOMP operation.
 <a name="operationBindingsObjectRedis"></a>`redis` | [Redis Operation Binding](https://github.com/asyncapi/bindings/blob/master/redis#operation) | Protocol-specific information for a Redis operation.
 <a name="operationBindingsObjectMercure"></a>`mercure` | [Mercure Operation Binding](https://github.com/asyncapi/bindings/blob/master/mercure#operation) | Protocol-specific information for a Mercure operation.
+<a name="operationBindingsObjectIBMMQ"></a>`ibmmq` | [IBM MQ Operation Binding](https://github.com/asyncapi/bindings/blob/master/ibmmq#operation-binding-object) | Protocol-specific information for an IBM MQ operation.
 
 This object MAY be extended with [Specification Extensions](#specificationExtensions).
 


### PR DESCRIPTION
I found that we have forgot to define (probably it's a bug) definition for `IBM MQ Operation Binding`. I know that some bindings don't need to have definition for particular kind of binding, but we should have reserved keywords.

I found it in review of https://github.com/asyncapi/spec/pull/836 PR 

cc @derberg @fmvilas and @dalelane you should be most interested :)