### PR TITLE
chore: fix example for operation security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+.github/.DS_Store

--- a/examples/operation-security.yml
+++ b/examples/operation-security.yml
@@ -22,8 +22,8 @@ channels:
                 enum:
                   - application/json
       security:
-        petstore_auth:
-          - subscribe:auth_revocations
+        - petstore_auth:
+            - subscribe:auth_revocations
 components:
   messages:
     message:


### PR DESCRIPTION
`security` property on operation level is supposed to be an array of security requirement objects and not a single object -> https://www.asyncapi.com/docs/reference/specification/v2.5.0#operationObject

example before fix: https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/asyncapi/spec/master/examples/operation-security.yml

example after fix: https://studio.asyncapi.com/?url=https://raw.githubusercontent.com/derberg/asyncapi/c61b29329b73867f98914c607f03015549169c34/examples/operation-security.yml
