### PR TITLE
chore: update asyncapi versions in the social-media example

### DIFF
--- a/examples/social-media/backend/asyncapi.yaml
+++ b/examples/social-media/backend/asyncapi.yaml
@@ -1,4 +1,4 @@
-asyncapi: 2.2.0
+asyncapi: 2.5.0
 
 info:
   title: Website Backend

--- a/examples/social-media/comments-service/asyncapi.yaml
+++ b/examples/social-media/comments-service/asyncapi.yaml
@@ -1,4 +1,4 @@
-asyncapi: 2.2.0
+asyncapi: 2.5.0
 
 info:
   title: Comments Service

--- a/examples/social-media/frontend/asyncapi.yaml
+++ b/examples/social-media/frontend/asyncapi.yaml
@@ -1,4 +1,4 @@
-asyncapi: 2.2.0
+asyncapi: 2.5.0
 
 info:
   title: Website WebSocket Client

--- a/examples/social-media/notification-service/asyncapi.yaml
+++ b/examples/social-media/notification-service/asyncapi.yaml
@@ -1,4 +1,4 @@
-asyncapi: 2.2.0
+asyncapi: 2.5.0
 
 info:
   title: Notifications Service

--- a/examples/social-media/public-api/asyncapi.yaml
+++ b/examples/social-media/public-api/asyncapi.yaml
@@ -1,4 +1,4 @@
-asyncapi: 2.2.0
+asyncapi: 2.5.0
 
 info:
   title: Public API 


### PR DESCRIPTION
---
title: "chore: update asyncapi versions in the social-media example"
---

I wanted to test some spec (that is somewhere on the web) with refs to the files and I noticed that the `social-media` example points to old version of AsyncAPI.