### PR TITLE
ci: fix spec update in website workflow

### DIFF
--- a/.github/workflows/update-spec.yaml
+++ b/.github/workflows/update-spec.yaml
@@ -30,7 +30,7 @@ jobs:
           git config --global user.email info@asyncapi.io
       - name: Get latest release
         id: latest_version
-        uses: abatilo/release-info-action@v1.3.0
+        uses: abatilo/release-info-action@5774bec4e3eabad433b4ae8f625e83afa0e7bb22 # 1.3.2 release https://github.com/abatilo/release-info-action/releases/tag/v1.3.2
         with:
           owner: asyncapi
           repo: spec


### PR DESCRIPTION
## Error

[This CI run](https://github.com/asyncapi/spec/actions/runs/4594476058/jobs/8113554780) overwrote spec document from release candidate, in the website.

## Reason

The action that we used to check the spec version that should be updated, did not take into consideration pre-releases, and instead of getting from API latest release as `2.6` it fetched the last release candidate

## Fix

Upgraded the workflow to use the latest version of the action that we use, that is fixed and fetch latest release, not pre-releases. I'm not using version number but commit as it is the most recommended and secure way to use non official actions that we do not control