### PR TITLE
docs: remove info about compatibility with openapi

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -4,9 +4,9 @@ This version is not yet ready to be used. We're currently working on it. If you 
 
 # AsyncAPI Specification
 
-#### Disclaimer
+#### Attribution
 
-Part of this content has been taken from the great work done by the folks at the [OpenAPI Initiative](https://openapis.org). Mainly because **it's a great work** and we want to keep as much compatibility as possible with the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification).
+Part of this content has been taken from the great work done by the folks at the [OpenAPI Initiative](https://openapis.org).
 
 #### Version 3.0.0
 


### PR DESCRIPTION
With 3.0 spec we are no longer really aiming for compatibility with OpenAPI, other than we do with other specs on schema level.

In other words, on schema level we still support OpenAPI Schema, Avro and many others.

So basically in case of OpenAPI there is no special treatment.

This is why this PR removes old 2.0 sentence about compatibility and instead we just leave the attribution for the great work of OpenAPI folks that inspired AsyncAPI

---
some more context: https://youtu.be/7urTb207V-8?t=121