### PR TITLE
docs: add info that runtime expression is used by reply obj

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -2602,7 +2602,7 @@ location: $message.header#/correlationId
 ### <a name="runtimeExpression"></a>Runtime Expression
 
 A runtime expression allows values to be defined based on information that will be available within the message.
-This mechanism is used by [Correlation ID Object](#correlationIdObject).
+This mechanism is used by [Correlation ID Object](#correlationIdObject) and [Operation Reply Address Object](#operationReplyAddressObject).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax:
 


### PR DESCRIPTION
small stuff that we forgot, just noticed today when I was explaining req/rep to one of content contributors