### PR TITLE
fix: trigger release with fixed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: 'Create GitHub release' 
     runs-on: ubuntu-latest
+    steps:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Setup Node.js


### PR DESCRIPTION
Just noticed we had no release candidate since May 30 -> https://github.com/asyncapi/spec/releases/tag/v3.0.0-next-major-spec.12