### PR TITLE
docs: operation trait object description

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -925,7 +925,7 @@ reply:
 
 #### <a name="operationTraitObject"></a>Operation Trait Object
 
-Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except the `action`, `channel` and `traits` ones.
+Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except the `action`, `channel`, `messages` and `traits` ones.
 
 If you're looking to apply traits to a message, see the [Message Trait Object](#messageTraitObject).
 


### PR DESCRIPTION
---
title: "FIX: operation trait object description"
---

---

## **Related issue(s):** fixes: #994

| Earlier                                                                                                                                   | Now                                                                                               |
| ----------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
| the description didn't exclude the `messages` field as `operation trait object` doesn't have `messages` field like `action` or `channel`. | the exclusion list includes the `messages` field as well along with others.                       |
| ![Earlier](https://github.com/asyncapi/spec/assets/96991785/76782399-abde-4b70-8a16-4c832759b303)                                         | ![Updated](https://github.com/asyncapi/spec/assets/96991785/0c4440b5-4eeb-4909-b7ab-62b32351680f) |

Add the ✏️ Editorial label.

NOTE: I found a number of MarkDown linting errors. Just want to confirm is it fine to Push the refactored changes in the same Pull Request or open a New Pull Request.

> Always make sure that the specification markdown file has no markdown-related errors.
