### PR TITLE
docs: update asyncapi document definition

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -14,8 +14,7 @@ The AsyncAPI Specification is licensed under [The Apache License, Version 2.0](h
 
 The AsyncAPI Specification is a project used to describe message-driven APIs in a machine-readable format. It’s protocol-agnostic, so you can use it for APIs that work over any protocol (e.g., AMQP, MQTT, WebSockets, Kafka, STOMP, HTTP, Mercure, etc).
 
-The AsyncAPI Specification defines a set of files required to describe the API of an [application](#definitionsApplication).
-These files can be used to create utilities, such as documentation, code, integration, or testing tools.
+The AsyncAPI Specification defines a set of fields that can be used in an AsyncAPI document to describe an [application](#definitionsApplication)'s API. The document may reference other files for additional details or shared fields, but it is typically a single, primary document that encapsulates the API description.
 
 The file(s) SHOULD describe the operations an [application](#definitionsApplication) performs. For instance, consider the following AsyncAPI definition snippet:
 

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -16,7 +16,7 @@ The AsyncAPI Specification is a project used to describe message-driven APIs in 
 
 The AsyncAPI Specification defines a set of fields that can be used in an AsyncAPI document to describe an [application](#definitionsApplication)'s API. The document may reference other files for additional details or shared fields, but it is typically a single, primary document that encapsulates the API description.
 
-The file(s) SHOULD describe the operations an [application](#definitionsApplication) performs. For instance, consider the following AsyncAPI definition snippet:
+The AsyncAPI document SHOULD describe the operations an [application](#definitionsApplication) performs. For instance, consider the following AsyncAPI definition snippet:
 
 ```yaml
 channels:


### PR DESCRIPTION
The original spec text seems to inaccurately suggest that multiple AsyncAPI documents are required for each application, whereas the correct statement would be that a single AsyncAPI document, potentially referencing other files, is typically used to describe an application's API.

Perhaps it is more accurate to say that the AsyncAPI Specification defines a set of fields that can be used in one or more AsyncAPI documents to describe an application's API. A single AsyncAPI document can reference other files, but it doesn't mean that multiple AsyncAPI documents are required for a single application.

While the AsyncAPI document is the primary file describing the API, it can include references to other files that contain additional details or shared fields. This doesn't equate to requiring multiple AsyncAPI documents for a single application.

### related to https://github.com/asyncapi/website/pull/1868/files#r1424279213 