### PR TITLE
chore: update reference to gravitee sponsor logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Want to become a sponsor? Learn [what we do with sponsors' money](https://www.as
 </a>
 &nbsp;&nbsp;&nbsp;&nbsp;
 <a href="https://www.gravitee.io" target="_blank">
-  <img src="./assets/gravitee.png" alt="Gravitee logo" height="70">
+  <img src="./assets/Gravitee.png" alt="Gravitee logo" height="70">
 </a>
 
 ### Gold


### PR DESCRIPTION
yeah, I forgot in local it doesn't matter if I have upper or lower case but then in github it is not file path but actually a URL - and basically logo do not render in readme

![Screenshot 2024-06-12 at 16 43 40](https://github.com/asyncapi/spec/assets/6995927/caa2fc3c-dfec-4541-9879-b195d97c1a1b)
