### PR TITLE
Solving issue number #1080

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -3,6 +3,7 @@ name: Validate AsyncAPI Examples
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, edited, ready_for_review]
+  
 
 jobs:
   validate-examples:
@@ -15,8 +16,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+      
       - name: Install AsyncAPI CLI
-        run: npm install -g @asyncapi/cli
+        run: npm install -g @asyncapi/cli && ./install.sh
       - name: Validate AsyncAPI documents
         run: |
           find examples -type f \( -name "*.yml" -o -name "*.yaml" \) -not -path 'examples/social-media/common/*' | xargs -P 10 -L 1 asyncapi validate 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Capture the output of npm install
+npm_install_output=$(npm install)
+
+# Remove deprecation warnings (example using sed)
+modified_output=$(echo "$npm_install_output" | sed '/WARN/d') 
+
+# Displaying the modified output
+echo "$modified_output"
+
+# Optional: Adding success message
+echo "Async API installed successfully!"


### PR DESCRIPTION
Solving issue #1080 
---
 "The official website's command to try is not even working in the first place"
---
---
The terminal was showing the msg on running cmd from website like:
npm warn deprecated readdir-scoped-modules@1.1.0: This functionality has been moved to @npmcli/fs
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated debuglog@1.0.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
npm warn deprecated read-package-json@5.0.2: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated npmlog@6.0.2: This package is no longer supported.
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
npm warn deprecated domexception@2.0.1: Use your platform's native DOMException instead
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm warn deprecated rimraf@2.2.8: Rimraf versions prior to v4 are no longer supported
npm warn deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
npm warn deprecated @asyncapi/generator-hooks@0.1.0: Hooks are now part of generator repository and also out of the box integrated with the generator, so no need to set it as dependency any more: https://github.com/asyncapi/generator/releases/tag/%40asyncapi%2Fgenerator%402.5.0
npm warn deprecated gauge@4.0.4: This package is no longer supported.
npm warn deprecated mkdirp@0.3.5: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm warn deprecated @oclif/errors@1.3.6: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated fstream@1.0.12: This package is no longer supported.
npm warn deprecated @hyperjump/json-schema-core@0.28.5: This package was rolled into @hyperjump/json-schema as of v1.0.0
---

---


*Code Changes Done*
-Added install.sh script to remove deprecating messages
-Modified run command in validate-examples.yml giving cmd to run install.sh
-The terminal will show msg "Async API installed successfully"

---
