### PR TITLE
docs: update Message Example headers and payload

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1453,8 +1453,8 @@ Message Example Object represents an example of a [Message Object](#messageObjec
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageExampleObjectHeaders"></a>headers | `Map[string, any]` | The value of this field MUST validate against the [Message Object's headers](#messageObjectHeaders) field.
-<a name="messageExampleObjectPayload"></a>payload | `Map[string, any]` | The value of this field MUST validate against the [Message Object's payload](#messageObjectPayload) field.
+<a name="messageExampleObjectHeaders"></a>headers | `any` | The value of this field MUST validate against the [Message Object's headers](#messageObjectHeaders) field.
+<a name="messageExampleObjectPayload"></a>payload | `any` | The value of this field MUST validate against the [Message Object's payload](#messageObjectPayload) field.
 <a name="messageExampleObjectName"></a>name | `string` | A machine-friendly name.
 <a name="messageExampleObjectSummary"></a>summary | `string` |  A short summary of what the example is about.
 


### PR DESCRIPTION
According to JSON Schema headers and payload properties may be of any type

See:
- https://github.com/asyncapi/jasyncapi/pull/208
- https://github.com/asyncapi/spec-json-schemas/issues/560
- https://github.com/asyncapi/website/issues/3530