### PR TITLE
docs: add back extension support on Server Object

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -485,6 +485,8 @@ Field Name | Type | Description
 <a name="serverObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this server.
 <a name="serverObjectBindings"></a>bindings | [Server Bindings Object](#serverBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the server.
 
+This object MAY be extended with [Specification Extensions](#specificationExtensions).
+
 ##### Server Object Example
 
 A single server would be described as:


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/a1df48d9-1acb-4ce0-9abc-576501c1605b)


This pull request includes a small change to the `spec/asyncapi.md` file. The change adds information about the possibility of extending the server object with specification extensions.

* [`spec/asyncapi.md`](diffhunk://#diff-34bca0c91901dffce093114c7d4cac16477410fbca7cabf3a1b888d7dfc3eb4dR488-R489): Added a line indicating that the server object may be extended with [Specification Extensions](#specificationExtensions).