### PR TITLE
ci: fix path for docs update

### DIFF
--- a/.github/scripts/remove-toc.js
+++ b/.github/scripts/remove-toc.js
@@ -9,7 +9,7 @@ module.exports = (givenSpec) => {
   const startingLine = "## Table of Contents\n";
   const endingLine = "<!-- /TOC -->\n";
 
-  const specFile = fs.readFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`);
+  const specFile = fs.readFileSync(`./website/markdown/docs/reference/specification/${givenSpec}.md`);
 
   const startingIndex = specFile.indexOf(startingLine);
   const endingIndex = specFile.indexOf(endingLine);
@@ -21,5 +21,5 @@ module.exports = (givenSpec) => {
   const firstHalf = specFile.slice(0, startingIndex);
   const secondHalf = specFile.slice(endingIndex + endingLine.length);
   const specWithoutToc = `${firstHalf}${secondHalf}`;
-  fs.writeFileSync(`./website/pages/docs/reference/specification/${givenSpec}.md`, specWithoutToc);
+  fs.writeFileSync(`./website/markdown/docs/reference/specification/${givenSpec}.md`, specWithoutToc);
 }

--- a/.github/workflows/new-spec-release.yml
+++ b/.github/workflows/new-spec-release.yml
@@ -38,20 +38,20 @@ jobs:
           script: |
             const fs = require("fs");
 
-            const specFiles = fs.readdirSync("./website/pages/docs/reference/specification");
+            const specFiles = fs.readdirSync("./website/markdown/docs/reference/specification");
 
             const nextRelease = `${{github.event.release.tag_name}}`;
             const prefixRelease = nextRelease.split("-")[0];
 
             for (const filename of specFiles) {
               if (filename.startsWith(prefixRelease)) {
-                fs.unlinkSync(`./website/pages/docs/reference/specification/${filename}`);
+                fs.unlinkSync(`./website/markdown/docs/reference/specification/${filename}`);
               }
             }
       - name: Copy Spec file from Current Repo to Another
         working-directory: ./website
         run: |
-          cp ../spec/spec/asyncapi.md ./pages/docs/reference/specification/${{github.event.release.tag_name}}.md
+          cp ../spec/spec/asyncapi.md ./markdown/docs/reference/specification/${{github.event.release.tag_name}}.md
       - name: Remove Table of Contents from Spec
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
updated the  docs path from ./website/pages to ./website/markdown in .github/scripts/remove-toc.js and .github/workflows/new-spec-release.yml 

fixes #1137