### PR TITLE
docs: convert markdown anchors to kebab-case

### DIFF
--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -776,7 +776,7 @@ Holds a dictionary with all the [operations](#operation-object) this application
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="operations-object-operation"></a>{operationId} | [Operation Object](#operation-object) \| [Reference Object](#reference-object) | The operation this application MUST implement. The field name (`operationId`) MUST be a string used to identify the operation in the document where it is defined, and its value is **case-sensitive**. Tools and libraries MAY use the `operationId` to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="operations-object-operation"></a>\{operationId} | [Operation Object](#operation-object) \| [Reference Object](#reference-object) | The operation this application MUST implement. The field name (`operationId`) MUST be a string used to identify the operation in the document where it is defined, and its value is **case-sensitive**. Tools and libraries MAY use the `operationId` to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
 
 ##### Operations Object Example
 

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -14,9 +14,9 @@ The AsyncAPI Specification is licensed under [The Apache License, Version 2.0](h
 
 The AsyncAPI Specification is a project used to describe message-driven APIs in a machine-readable format. It’s protocol-agnostic, so you can use it for APIs that work over any protocol (e.g., AMQP, MQTT, WebSockets, Kafka, STOMP, HTTP, Mercure, etc).
 
-The AsyncAPI Specification defines a set of fields that can be used in an AsyncAPI document to describe an [application](#definitionsApplication)'s API. The document may reference other files for additional details or shared fields, but it is typically a single, primary document that encapsulates the API description.
+The AsyncAPI Specification defines a set of fields that can be used in an AsyncAPI document to describe an [application](#definitions-application)'s API. The document may reference other files for additional details or shared fields, but it is typically a single, primary document that encapsulates the API description.
 
-The AsyncAPI document SHOULD describe the operations an [application](#definitionsApplication) performs. For instance, consider the following AsyncAPI definition snippet:
+The AsyncAPI document SHOULD describe the operations an [application](#definitions-application) performs. For instance, consider the following AsyncAPI definition snippet:
 
 ```yaml
 channels:
@@ -29,11 +29,11 @@ operations:
       $ref: '#/channels/userSignedUp'
 ```
 
-It means that the [application](#definitionsApplication) will receive messages from  the `userSignedUp` [channel](#definitionsChannel).
+It means that the [application](#definitions-application) will receive messages from  the `userSignedUp` [channel](#definitions-channel).
 
 **The AsyncAPI specification does not assume any kind of software topology, architecture or pattern.** Therefore, a server MAY be a message broker, a web server or any other kind of computer program capable of sending and/or receiving data. However, AsyncAPI offers a mechanism called "bindings" that aims to help with more specific information about the protocol.
 
-It's NOT RECOMMENDED to derive a [receiver](#definitionsReceiver) AsyncAPI document from a [sender](#definitionsSender) one or vice versa. There are no guarantees that the channel used by an application to receive messages will be the same channel where another application is sending them. Also, certain fields in the document like `summary`, `description`, and the id of the operation might stop making sense. For instance, given the following receiver snippet:
+It's NOT RECOMMENDED to derive a [receiver](#definitions-receiver) AsyncAPI document from a [sender](#definitions-sender) one or vice versa. There are no guarantees that the channel used by an application to receive messages will be the same channel where another application is sending them. Also, certain fields in the document like `summary`, `description`, and the id of the operation might stop making sense. For instance, given the following receiver snippet:
 
 ```yaml
 operations:
@@ -63,90 +63,90 @@ Aside from the issues mentioned above, there may also be infrastructure configur
 <!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
 
 - [Definitions](#definitions)
-  - [Server](#definitionsServer)
-  - [Application](#definitionsApplication)
-  - [Sender](#definitionsSender)
-  - [Receiver](#definitionsReceiver)
-  - [Message](#definitionsMessage)
-  - [Channel](#definitionsChannel)
-  - [Protocol](#definitionsProtocol)
+  - [Server](#definitions-server)
+  - [Application](#definitions-application)
+  - [Sender](#definitions-sender)
+  - [Receiver](#definitions-receiver)
+  - [Message](#definitions-message)
+  - [Channel](#definitions-channel)
+  - [Protocol](#definitions-protocol)
 - [Specification](#specification)
   - [Format](#format)
   - [File Structure](#file-structure)
   - [Absolute URLs](#absolute-urls)
   - [Schema](#schema)
-    - [AsyncAPI Object](#A2SObject)
-    - [AsyncAPI Version String](#A2SVersionString)
-    - [Identifier](#A2SIdString)
-    - [Info Object](#infoObject)
-    - [Contact Object](#contactObject)
-    - [License Object](#licenseObject)
-    - [Servers Object](#serversObject)
-    - [Server Object](#serverObject)
-    - [Server Variable Object](#serverVariableObject)
-    - [Default Content Type](#defaultContentTypeString)
-    - [Channels Object](#channelsObject)
-    - [Channel Object](#channelObject)
-    - [Operations Object](#operationsObject)
-    - [Operation Object](#operationObject)
-    - [Operation Trait Object](#operationTraitObject)
-    - [Operation Reply Object](#operationReplyObject)
-    - [Operation Reply Address Object](#operationReplyAddressObject)
-    - [Message Object](#messageObject)
-    - [Message Trait Object](#messageTraitObject)
-    - [Message Example Object](#messageExampleObject)
-    - [Tags Object](#tagsObject)
+    - [AsyncAPI Object](#a2s-object)
+    - [AsyncAPI Version String](#a2s-version-string)
+    - [Identifier](#a2s-id-string)
+    - [Info Object](#info-object)
+    - [Contact Object](#contact-object)
+    - [License Object](#license-object)
+    - [Servers Object](#servers-object)
+    - [Server Object](#server-object)
+    - [Server Variable Object](#server-variable-object)
+    - [Default Content Type](#default-content-type-string)
+    - [Channels Object](#channels-object)
+    - [Channel Object](#channel-object)
+    - [Operations Object](#operations-object)
+    - [Operation Object](#operation-object)
+    - [Operation Trait Object](#operation-trait-object)
+    - [Operation Reply Object](#operation-reply-object)
+    - [Operation Reply Address Object](#operation-reply-address-object)
+    - [Message Object](#message-object)
+    - [Message Trait Object](#message-trait-object)
+    - [Message Example Object](#message-example-object)
+    - [Tags Object](#tags-object)
     - [Tag Object](#tag-object)
-    - [External Documentation Object](#externalDocumentationObject)
-    - [Components Object](#componentsObject)
-    - [Reference Object](#referenceObject)
-    - [Multi Format Schema Object](#multiFormatSchemaObject)
-    - [Schema Object](#schemaObject)
-    - [Security Scheme Object](#securitySchemeObject)
-    - [OAuth Flows Object](#oauth-flows-object)  
+    - [External Documentation Object](#external-documentation-object)
+    - [Components Object](#components-object)
+    - [Reference Object](#reference-object)
+    - [Multi Format Schema Object](#multi-format-schema-object)
+    - [Schema Object](#schema-object)
+    - [Security Scheme Object](#security-scheme-object)
+    - [OAuth Flows Object](#oauth-flows-object)
     - [OAuth Flow Object](#oauth-flow-object)
-    - [Server Bindings Object](#serverBindingsObject)
-    - [Parameters Object](#parametersObject)
-    - [Parameter Object](#parameterObject)
-    - [Channel Bindings Object](#channelBindingsObject)
-    - [Operation Bindings Object](#operationBindingsObject)
-    - [Message Bindings Object](#messageBindingsObject)
-    - [Correlation ID Object](#correlationIdObject)
-    - [Specification Extensions](#specificationExtensions)
+    - [Server Bindings Object](#server-bindings-object)
+    - [Parameters Object](#parameters-object)
+    - [Parameter Object](#parameter-object)
+    - [Channel Bindings Object](#channel-bindings-object)
+    - [Operation Bindings Object](#operation-bindings-object)
+    - [Message Bindings Object](#message-bindings-object)
+    - [Correlation ID Object](#correlation-id-object)
+    - [Specification Extensions](#specification-extensions)
 
 <!-- /TOC -->
 
 ## <a name="definitions"></a>Definitions
 
-### <a name="definitionsServer"></a>Server
+### <a name="definitions-server"></a>Server
 
-A server MAY be a message broker that is capable of sending and/or receiving between a [sender](#definitionsSender) and [receiver](#definitionsReceiver). A server MAY be a service with WebSocket API that enables message-driven communication between browser-to-server or server-to-server.
+A server MAY be a message broker that is capable of sending and/or receiving between a [sender](#definitions-sender) and [receiver](#definitions-receiver). A server MAY be a service with WebSocket API that enables message-driven communication between browser-to-server or server-to-server.
 
-### <a name="definitionsApplication"></a>Application
+### <a name="definitions-application"></a>Application
 
-An application is any kind of computer program or a group of them. It MUST be a [sender](#definitionsSender), a [receiver](#definitionsReceiver), or both. An application MAY be a microservice, IoT device (sensor), mainframe process, message broker, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitionsProtocol). An application MUST also use a protocol supported by the [server](#definitionsServer) in order to connect and exchange [messages](#definitionsMessage), or expose the protocol described in the AsyncAPI document.
+An application is any kind of computer program or a group of them. It MUST be a [sender](#definitions-sender), a [receiver](#definitions-receiver), or both. An application MAY be a microservice, IoT device (sensor), mainframe process, message broker, etc. An application MAY be written in any number of different programming languages as long as they support the selected [protocol](#definitions-protocol). An application MUST also use a protocol supported by the [server](#definitions-server) in order to connect and exchange [messages](#definitions-message), or expose the protocol described in the AsyncAPI document.
 
-### <a name="definitionsSender"></a>Sender
+### <a name="definitions-sender"></a>Sender
 
-A sender is a type of application, that is sending [messages](#definitionsMessage) to [channels](#definitionsChannel). A sender MAY send to multiple channels depending on the [server](#definitionsServer), protocol, and use-case pattern.
+A sender is a type of application, that is sending [messages](#definitions-message) to [channels](#definitions-channel). A sender MAY send to multiple channels depending on the [server](#definitions-server), protocol, and use-case pattern.
 
-### <a name="definitionsReceiver"></a>Receiver
+### <a name="definitions-receiver"></a>Receiver
 
-A receiver is a type of application that is receiving [messages](#definitionsMessage) from [channels](#definitionsChannel). A receiver MAY receive from multiple channels depending on the [server](#definitionsServer), protocol, and the use-case pattern. A receiver MAY forward a received message further without changing it. A receiver MAY act as a consumer and react to the message. A receiver MAY act as a processor that, for example, aggregates multiple messages in one and forwards them.
+A receiver is a type of application that is receiving [messages](#definitions-message) from [channels](#definitions-channel). A receiver MAY receive from multiple channels depending on the [server](#definitions-server), protocol, and the use-case pattern. A receiver MAY forward a received message further without changing it. A receiver MAY act as a consumer and react to the message. A receiver MAY act as a processor that, for example, aggregates multiple messages in one and forwards them.
 
-### <a name="definitionsMessage"></a>Message
+### <a name="definitions-message"></a>Message
 
-A message is the mechanism by which information is exchanged via a channel between [servers](#definitionsServer) and applications. A message MAY contain a payload and MAY also contain headers. The headers MAY be subdivided into [protocol](#definitionsProtocol)-defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response.
+A message is the mechanism by which information is exchanged via a channel between [servers](#definitions-server) and applications. A message MAY contain a payload and MAY also contain headers. The headers MAY be subdivided into [protocol](#definitions-protocol)-defined headers and header properties defined by the application which can act as supporting metadata. The payload contains the data, defined by the application, which MUST be serialized into a format (JSON, XML, Avro, binary, etc.). Since a message is a generic mechanism, it can support multiple interaction patterns such as event, command, request, or response.
 
-### <a name="definitionsChannel"></a>Channel
+### <a name="definitions-channel"></a>Channel
 
-A channel is an addressable component, made available by the [server](#definitionsServer), for the organization of [messages](#definitionsMessage). [Sender](#definitionsSender) applications send messages to channels and [receiver](#definitionsReceiver) applications receive messages from channels. [Servers](#definitionsServer) MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the [server](#definitionsServer) implementation, the channel MAY be included in the message via protocol-defined headers.
+A channel is an addressable component, made available by the [server](#definitions-server), for the organization of [messages](#definitions-message). [Sender](#definitions-sender) applications send messages to channels and [receiver](#definitions-receiver) applications receive messages from channels. [Servers](#definitions-server) MAY support many channel instances, allowing messages with different content to be addressed to different channels. Depending on the [server](#definitions-server) implementation, the channel MAY be included in the message via protocol-defined headers.
 
-### <a name="definitionsProtocol"></a>Protocol
+### <a name="definitions-protocol"></a>Protocol
 
-A protocol is the mechanism (wireline protocol or API) by which [messages](#definitionsMessage) are exchanged between the application and the [channel](#definitionsChannel). Example protocols include, but are not limited to, AMQP, HTTP, JMS, Kafka, Anypoint MQ, MQTT, Solace, STOMP, Mercure, WebSocket, Google Pub/Sub, Pulsar.  
+A protocol is the mechanism (wireline protocol or API) by which [messages](#definitions-message) are exchanged between the application and the [channel](#definitions-channel). Example protocols include, but are not limited to, AMQP, HTTP, JMS, Kafka, Anypoint MQ, MQTT, Solace, STOMP, Mercure, WebSocket, Google Pub/Sub, Pulsar.  
 
-### <a name="definitionsBindings"></a>Bindings
+### <a name="definitions-bindings"></a>Bindings
 
 A "binding" (or "protocol binding") is a mechanism to define protocol-specific information. Therefore, a protocol binding MUST define protocol-specific information only.
 
@@ -181,9 +181,9 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 ### <a name="file-structure"></a>File Structure
 
 An AsyncAPI document MAY be made up of a single document or be divided into multiple,
-connected parts at the discretion of the author. In the latter case, [Reference Objects](#referenceObject) are used.
+connected parts at the discretion of the author. In the latter case, [Reference Objects](#reference-object) are used.
 
-It is important to note that everything that is defined in an AsyncAPI document MUST be used by the implemented [Application](#definitionsApplication), with the exception of the [Components Object](#componentsObject). Everything that is defined inside the Components Object represents a resource that MAY or MAY NOT be used by the implemented [Application](#definitionsApplication).
+It is important to note that everything that is defined in an AsyncAPI document MUST be used by the implemented [Application](#definitions-application), with the exception of the [Components Object](#components-object). Everything that is defined inside the Components Object represents a resource that MAY or MAY NOT be used by the implemented [Application](#definitions-application).
 
 By convention, the AsyncAPI Specification (A2S) file is named `asyncapi.json` or `asyncapi.yaml`.
 
@@ -193,7 +193,7 @@ Unless specified otherwise, all properties that are absolute URLs are defined by
 
 ### <a name="schema"></a>Schema
 
-#### <a name="A2SObject"></a>AsyncAPI Object
+#### <a name="a2s-object"></a>AsyncAPI Object
 
 This is the root document object for the API specification.
 It combines resource listing and API declaration together into one document.
@@ -202,18 +202,18 @@ It combines resource listing and API declaration together into one document.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="A2SAsyncAPI"></a>asyncapi | [AsyncAPI Version String](#A2SVersionString) | **REQUIRED.** Specifies the AsyncAPI Specification version being used. It can be used by tooling Specifications and clients to interpret the version. The structure shall be `major`.`minor`.`patch`, where `patch` versions _must_ be compatible with the existing `major`.`minor` tooling. Typically patch versions will be introduced to address errors in the documentation, and tooling should typically be compatible with the corresponding `major`.`minor` (1.0.*). Patch versions will correspond to patches of this document.
-<a name="A2SId"></a>id | [Identifier](#A2SIdString) | Identifier of the [application](#definitionsApplication) the AsyncAPI document is defining.
-<a name="A2SInfo"></a>info | [Info Object](#infoObject) | **REQUIRED.** Provides metadata about the API. The metadata can be used by the clients if needed.
-<a name="A2SServers"></a>servers | [Servers Object](#serversObject) | Provides connection details of servers.
-<a name="A2SDefaultContentType"></a>defaultContentType | [Default Content Type](#defaultContentTypeString) | Default content type to use when encoding/decoding a message's payload.
-<a name="A2SChannels"></a>channels | [Channels Object](#channelsObject) | The channels used by this [application](#definitionsApplication).
-<a name="A2SOperations"></a>operations | [Operations Object](#operationsObject) | The operations this [application](#definitionsApplication) MUST implement.
-<a name="A2SComponents"></a>components | [Components Object](#componentsObject) | An element to hold various reusable objects for the specification. Everything that is defined inside this object represents a resource that MAY or MAY NOT be used in the rest of the document and MAY or MAY NOT be used by the implemented [Application](#definitionsApplication).
+<a name="a2s-asyncAPI"></a>asyncapi | [AsyncAPI Version String](#a2s-version-string) | **REQUIRED.** Specifies the AsyncAPI Specification version being used. It can be used by tooling Specifications and clients to interpret the version. The structure shall be `major`.`minor`.`patch`, where `patch` versions _must_ be compatible with the existing `major`.`minor` tooling. Typically patch versions will be introduced to address errors in the documentation, and tooling should typically be compatible with the corresponding `major`.`minor` (1.0.*). Patch versions will correspond to patches of this document.
+<a name="a2s-id"></a>id | [Identifier](#a2s-id-string) | Identifier of the [application](#definitions-application) the AsyncAPI document is defining.
+<a name="a2s-info"></a>info | [Info Object](#info-object) | **REQUIRED.** Provides metadata about the API. The metadata can be used by the clients if needed.
+<a name="a2s-servers"></a>servers | [Servers Object](#servers-object) | Provides connection details of servers.
+<a name="a2s-default-content-type"></a>defaultContentType | [Default Content Typ(#default-content-type-string) | Default content type to use when encoding/decoding a message's payload.
+<a name="a2s-channels"></a>channels | [Channels Object](#channels-object) | The channels used by this [application](#definitions-application).
+<a name="a2s-operations"></a>operations | [Operations Object](#operations-object) | The operations this [application](#definitions-application) MUST implement.
+<a name="a2s-components"></a>components | [Components Object](#components-object) | An element to hold various reusable objects for the specification. Everything that is defined inside this object represents a resource that MAY or MAY NOT be used in the rest of the document and MAY or MAY NOT be used by the implemented [Application](#definitions-application).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="A2SVersionString"></a>AsyncAPI Version String
+#### <a name="a2s-version-string"></a>AsyncAPI Version String
 
 The version string signifies the version of the AsyncAPI Specification that the document complies to.
 The format for this string _must_ be `major`.`minor`.`patch`.  The `patch` _may_ be suffixed by a hyphen and extra alphanumeric characters.
@@ -223,9 +223,9 @@ The patch version will not be considered by tooling, making no distinction betwe
 
 In subsequent versions of the AsyncAPI Specification, care will be given such that increments of the `minor` version should not interfere with operations of tooling developed to a lower minor version. Thus a hypothetical `1.1.0` specification should be usable with tooling designed for `1.0.0`.
 
-#### <a name="A2SIdString"></a>Identifier
+#### <a name="a2s-id-string"></a>Identifier
 
-This field represents a unique universal identifier of the [application](#definitionsApplication) the AsyncAPI document is defining. It must conform to the URI format, according to [RFC3986](https://tools.ietf.org/html/rfc3986).
+This field represents a unique universal identifier of the [application](#definitions-application) the AsyncAPI document is defining. It must conform to the URI format, according to [RFC3986](https://tools.ietf.org/html/rfc3986).
 
 It is RECOMMENDED to use a [URN](https://tools.ietf.org/html/rfc8141) to globally and uniquely identify the application during long periods of time, even after it becomes unavailable or ceases to exist.
 
@@ -251,7 +251,7 @@ id: 'urn:example:com:smartylighting:streetlights:server'
 id: 'https://github.com/smartylighting/streetlights-server'
 ```
 
-#### <a name="infoObject"></a>Info Object
+#### <a name="info-object"></a>Info Object
 
 The object provides metadata about the API.
 The metadata can be used by the clients if needed.
@@ -260,16 +260,16 @@ The metadata can be used by the clients if needed.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="infoObjectTitle"></a>title | `string` | **REQUIRED.** The title of the application.
-<a name="infoObjectVersion"></a>version | `string` | **REQUIRED** Provides the version of the application API (not to be confused with the specification version).
-<a name="infoObjectDescription"></a>description | `string` | A short description of the application. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="infoObjectTermsOfService"></a>termsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of an absolute URL.
-<a name="infoObjectContact"></a>contact | [Contact Object](#contactObject) | The contact information for the exposed API.
-<a name="infoObjectLicense"></a>license | [License Object](#licenseObject) | The license information for the exposed API.
-<a name="infoObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for application API documentation control. Tags can be used for logical grouping of applications.
-<a name="infoObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation of the exposed API.
+<a name="info-object-title"></a>title | `string` | **REQUIRED.** The title of the application.
+<a name="info-object-version"></a>version | `string` | **REQUIRED** Provides the version of the application API (not to be confused with the specification version).
+<a name="info-object-description"></a>description | `string` | A short description of the application. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="info-object-terms-of-service"></a>termsOfService | `string` | A URL to the Terms of Service for the API. This MUST be in the form of an absolute URL.
+<a name="info-object-contact"></a>contact | [Contact Object](#contact-object) | The contact information for the exposed API.
+<a name="info-object-license"></a>license | [License Object](#license-object) | The license information for the exposed API.
+<a name="info-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for application API documentation control. Tags can be used for logical grouping of applications.
+<a name="info-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation of the exposed API.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Info Object Example
 
@@ -321,7 +321,7 @@ tags:
   - name: e-commerce
 ```
 
-#### <a name="contactObject"></a>Contact Object
+#### <a name="contact-object"></a>Contact Object
 
 Contact information for the exposed API.
 
@@ -329,11 +329,11 @@ Contact information for the exposed API.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="contactObjectName"></a>name | `string` | The identifying name of the contact person/organization.
-<a name="contactObjectUrl"></a>url | `string` | The URL pointing to the contact information. This MUST be in the form of an absolute URL.
-<a name="contactObjectEmail"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
+<a name="contact-object-name"></a>name | `string` | The identifying name of the contact person/organization.
+<a name="contact-object-url"></a>url | `string` | The URL pointing to the contact information. This MUST be in the form of an absolute URL.
+<a name="contact-object-email"></a>email | `string` | The email address of the contact person/organization. MUST be in the format of an email address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Contact Object Example
 
@@ -353,7 +353,7 @@ url: https://www.example.com/support
 email: support@example.com
 ```
 
-#### <a name="licenseObject"></a>License Object
+#### <a name="license-object"></a>License Object
 
 License information for the exposed API.
 
@@ -361,10 +361,10 @@ License information for the exposed API.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="licenseObjectName"></a>name | `string` | **REQUIRED.** The license name used for the API.
-<a name="licenseObjectUrl"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of an absolute URL.
+<a name="license-object-name"></a>name | `string` | **REQUIRED.** The license name used for the API.
+<a name="license-object-url"></a>url | `string` | A URL to the license used for the API. This MUST be in the form of an absolute URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### License Object Example
 
@@ -382,15 +382,15 @@ name: Apache 2.0
 url: https://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
-#### <a name="serversObject"></a>Servers Object
+#### <a name="servers-object"></a>Servers Object
 
-The Servers Object is a map of [Server Objects](#serverObject).
+The Servers Object is a map of [Server Objects](#server-object).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="serversObjectServer"></a>`^[A-Za-z0-9_\-]+$` | [Server Object](#serverObject) \| [Reference Object](#referenceObject) | The definition of a server this application MAY connect to.
+<a name="servers-object-server"></a>`^[A-Za-z0-9_\-]+$` | [Server Object](#server-object) \| [Reference Object](#reference-object) | The definition of a server this application MAY connect to.
 
 ##### Servers Object Example
 
@@ -464,7 +464,7 @@ production:
       description: 'This environment is the live environment available for final users.'
 ```
 
-#### <a name="serverObject"></a>Server Object
+#### <a name="server-object"></a>Server Object
 
 An object representing a message broker, a server or any other kind of computer program capable of sending and/or receiving data. This object is used to capture details such as URIs, protocols and security configuration. Variable substitution can be used so that some details, for example usernames and passwords, can be injected by code generation tools.
 
@@ -472,20 +472,20 @@ An object representing a message broker, a server or any other kind of computer 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="serverObjectHost"></a>host | `string` | **REQUIRED**. The server host name. It MAY include the port. This field supports [Server Variables](#serverObjectVariables). Variable substitutions will be made when a variable is named in `{`braces`}`.
-<a name="serverObjectProtocol"></a>protocol | `string` | **REQUIRED**. The protocol this server supports for connection.
-<a name="serverObjectProtocolVersion"></a>protocolVersion | `string` | The version of the protocol used for connection. For instance: AMQP `0.9.1`, HTTP `2.0`, Kafka `1.0.0`, etc.
-<a name="serverObjectPathname"></a>pathname | `string` | The path to a resource in the host. This field supports [Server Variables](#serverObjectVariables). Variable substitutions will be made when a variable is named in `{`braces`}`.
-<a name="serverObjectDescription"></a>description | `string` | An optional string describing the server. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverObjectTitle"></a>title | `string` | A human-friendly title for the server.
-<a name="serverObjectSummary"></a>summary | `string` | A short summary of the server.
-<a name="serverObjectVariables"></a>variables | Map[`string`, [Server Variable Object](#serverVariableObject) \| [Reference Object](#referenceObject)]] | A map between a variable name and its value.  The value is used for substitution in the server's `host` and `pathname` template.
-<a name="serverObjectSecurity"></a>security | [[Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | A declaration of which security schemes can be used with this server. The list of values includes alternative [security scheme objects](#securitySchemeObject) that can be used. Only one of the security scheme objects need to be satisfied to authorize a connection or operation.
-<a name="serverObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping and categorization of servers.
-<a name="serverObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this server.
-<a name="serverObjectBindings"></a>bindings | [Server Bindings Object](#serverBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the server.
+<a name="server-object-host"></a>host | `string` | **REQUIRED**. The server host name. It MAY include the port. This field supports [Server Variables](#server-object-variables). Variable substitutions will be made when a variable is named in `{`braces`}`.
+<a name="server-object-protocol"></a>protocol | `string` | **REQUIRED**. The protocol this server supports for connection.
+<a name="server-object-protocol-version"></a>protocolVersion | `string` | The version of the protocol used for connection. For instance: AMQP `0.9.1`, HTTP `2.0`, Kafka `1.0.0`, etc.
+<a name="server-object-pathname"></a>pathname | `string` | The path to a resource in the host. This field supports [Server Variables](#server-object-variables). Variable substitutions will be made when a variable is named in `{`braces`}`.
+<a name="server-object-description"></a>description | `string` | An optional string describing the server. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="server-object-title"></a>title | `string` | A human-friendly title for the server.
+<a name="server-object-summary"></a>summary | `string` | A short summary of the server.
+<a name="server-object-variables"></a>variables | Map[`string`, [Server Variable Object](#server-variable-object) \| [Reference Object](#reference-object)]] | A map between a variable name and its value.  The value is used for substitution in the server's `host` and `pathname` template.
+<a name="server-object-security"></a>security | [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object) | A declaration of which security schemes can be used with this server. The list of values includes alternative [security scheme objects](#security-scheme-object) that can be used. Only one of the security scheme objects need to be satisfied to authorize a connection or operation.
+<a name="server-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping and categorization of servers.
+<a name="server-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this server.
+<a name="server-object-bindings"></a>bindings | [Server Bindings Object](#server-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the server.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Object Example
 
@@ -529,7 +529,7 @@ protocol: amqp
 description: Production RabbitMQ broker (uses the `production` vhost).
 ```
 
-#### <a name="serverVariableObject"></a>Server Variable Object
+#### <a name="server-variable-object"></a>Server Variable Object
 
 An object representing a Server Variable for server URL template substitution.
 
@@ -537,12 +537,12 @@ An object representing a Server Variable for server URL template substitution.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="serverVariableObjectEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="serverVariableObjectDefault"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
-<a name="serverVariableObjectDescription"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="serverVariableObjectExamples"></a>examples | [`string`] | An array of examples of the server variable.
+<a name="server-variable-object-enum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
+<a name="server-variable-object-default"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
+<a name="server-variable-object-description"></a>description | `string` | An optional description for the server variable. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="server-variable-object-examples"></a>examples | [`string`] | An array of examples of the server variable.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Server Variable Object Example
 
@@ -579,9 +579,9 @@ variables:
       - staging
 ```
 
-#### <a name="defaultContentTypeString"></a>Default Content Type
+#### <a name="default-content-type-string"></a>Default Content Type
 
-A string representing the default content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). This value MUST be used by schema parsers when the [contentType](#messageObjectContentType) property is omitted.
+A string representing the default content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). This value MUST be used by schema parsers when the [contentType](#message-object-content-type) property is omitted.
 
 In case a message can't be encoded/decoded using this value, schema parsers MUST use their default content type.
 
@@ -599,15 +599,15 @@ In case a message can't be encoded/decoded using this value, schema parsers MUST
 defaultContentType: application/json
 ```
 
-#### <a name="channelsObject"></a>Channels Object
+#### <a name="channels-object"></a>Channels Object
 
-An object containing all the [Channel Object](#channelObject) definitions the [Application](#definitionsApplication) MUST use during runtime.
+An object containing all the [Channel Object](#channel-object) definitions the [Application](#definitions-application) MUST use during runtime.
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="channelsObjectChannel"></a>{channelId} | [Channel Object](#channelObject) \| [Reference Object](#referenceObject) | An identifier for the described channel. The `channelId` value is **case-sensitive**. Tools and libraries MAY use the `channelId` to uniquely identify a channel, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="channels-object-channel"></a>{channelId} | [Channel Object](#channel-object) \| [Reference Object](#reference-object) | An identifier for the described channel. The `channelId` value is **case-sensitive**. Tools and libraries MAY use the `channelId` to uniquely identify a channel, therefore, it is RECOMMENDED to follow common programming naming conventions.
 
 ##### Channels Object Example
 
@@ -634,7 +634,7 @@ userSignedUp:
       $ref: '#/components/messages/userSignedUp'
 ```
 
-#### <a name="channelObject"></a>Channel Object
+#### <a name="channel-object"></a>Channel Object
 
 Describes a shared communication channel.
 
@@ -642,18 +642,18 @@ Describes a shared communication channel.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="channelObjectAddress"></a>address | `string` \| `null` | An optional string representation of this channel's address. The address is typically the "topic name", "routing key", "event type", or "path". When `null` or absent, it MUST be interpreted as unknown. This is useful when the address is generated dynamically at runtime or can't be known upfront. It MAY contain [Channel Address Expressions](#channelAddressExpressions). Query parameters and fragments SHALL NOT be used, instead use [bindings](#channelBindingsObject) to define them.
-<a name="channelObjectMessages"></a>messages | [Messages Object](#messagesObject) | A map of the messages that will be sent to this channel by any application at any time. **Every message sent to this channel MUST be valid against one, and only one, of the [message objects](#messageObject) defined in this map.**
-<a name="channelObjectTitle"></a>title | `string` | A human-friendly title for the channel.
-<a name="channelObjectSummary"></a>summary | `string` | A short summary of the channel.
-<a name="channelObjectDescription"></a>description | `string` | An optional description of this channel. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="channelObjectServers"></a>servers | [[Reference Object](#referenceObject)] | An array of `$ref` pointers to the definition of the servers in which this channel is available. If the channel is located in the [root Channels Object](#channelsObject), it MUST point to a subset of server definitions located in the [root Servers Object](#serversObject), and MUST NOT point to a subset of server definitions located in the [Components Object](#componentsObject) or anywhere else. If the channel is located in the [Components Object](#componentsObject), it MAY point to a [Server Objects](#serverObject) in any location. If `servers` is absent or empty, this channel MUST be available on all the servers defined in the [Servers Object](#serversObject). Please note the `servers` property value MUST be an array of [Reference Objects](#referenceObject) and, therefore, MUST NOT contain an array of [Server Objects](#serverObject). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
-<a name="channelObjectParameters"></a>parameters | [Parameters Object](#parametersObject) | A map of the parameters included in the channel address. It MUST be present only when the address contains [Channel Address Expressions](#channelAddressExpressions).
-<a name="channelObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping of channels.
-<a name="channelObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this channel.
-<a name="channelObjectBindings"></a>bindings | [Channel Bindings Object](#channelBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the channel.
+<a name="channel-object-address"></a>address | `string` \| `null` | An optional string representation of this channel's address. The address is typically the "topic name", "routing key", "event type", or "path". When `null` or absent, it MUST be interpreted as unknown. This is useful when the address is generated dynamically at runtime or can't be known upfront. It MAY contain [Channel Address Expressions](#channel-address-expressions). Query parameters and fragments SHALL NOT be used, instead use [bindings](#channel-bindings-object) to define them.
+<a name="channel-object-messages"></a>messages | [Messages Object](#messages-object) | A map of the messages that will be sent to this channel by any application at any time. **Every message sent to this channel MUST be valid against one, and only one, of the [message objects](#message-object) defined in this map.**
+<a name="channel-object-title"></a>title | `string` | A human-friendly title for the channel.
+<a name="channel-object-summary"></a>summary | `string` | A short summary of the channel.
+<a name="channel-object-description"></a>description | `string` | An optional description of this channel. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="channel-object-servers"></a>servers | [Reference Object](#reference-object) | An array of `$ref` pointers to the definition of the servers in which this channel is available. If the channel is located in the [root Channels Object](#channels-object), it MUST point to a subset of server definitions located in the [root Servers Object](#servers-object), and MUST NOT point to a subset of server definitions located in the [Components Object](#components-object) or anywhere else. If the channel is located in the [Components Object](#components-object), it MAY point to a [Server Objects](#server-object) in any location. If `servers` is absent or empty, this channel MUST be available on all the servers defined in the [Servers Object](#servers-object). Please note the `servers` property value MUST be an array of [Reference Objects](#reference-object) and, therefore, MUST NOT contain an array of [Server Objects](#server-object). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
+<a name="channel-object-parameters"></a>parameters | [Parameters Object](#parameters-object) | A map of the parameters included in the channel address. It MUST be present only when the address contains [Channel Address Expressions](#channel-address-expressions).
+<a name="channel-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping of channels.
+<a name="channel-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this channel.
+<a name="channel-object-bindings"></a>bindings | [Channel Bindings Object](#channel-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the channel.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Channel Object Example
 
@@ -728,13 +728,13 @@ externalDocs:
   url: 'https://example.com'
 ```
 
-#### <a name="channelAddressExpressions"></a>Channel Address Expressions
+#### <a name="channel-address-expressions"></a>Channel Address Expressions
 
 Channel addresses MAY contain expressions that can be used to define dynamic values.
 
 Expressions MUST be composed by a name enclosed in curly braces (`{` and `}`). E.g., `{userId}`.
 
-#### <a name="messagesObject"></a>Messages Object
+#### <a name="messages-object"></a>Messages Object
 
 Describes a map of messages included in a channel.
 
@@ -742,7 +742,7 @@ Describes a map of messages included in a channel.
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="messagesObjectId"></a>`{messageId}` | [Message Object](#messageObject) \| [Reference Object](#referenceObject) | The key represents the message identifier. The `messageId` value is **case-sensitive**. Tools and libraries MAY use the `messageId` value to uniquely identify a message, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="messages-object-id"></a>`{messageId}` | [Message Object](#message-object) \| [Reference Object](#reference-object) | The key represents the message identifier. The `messageId` value is **case-sensitive**. Tools and libraries MAY use the `messageId` value to uniquely identify a message, therefore, it is RECOMMENDED to follow common programming naming conventions.
 
 ##### Messages Object Example
 
@@ -766,17 +766,17 @@ userCompletedOrder:
   $ref: '#/components/messages/userCompletedOrder'
 ```
 
-#### <a name="operationsObject"></a>Operations Object
+#### <a name="operations-object"></a>Operations Object
 
-Holds a dictionary with all the [operations](#operationObject) this application MUST implement.
+Holds a dictionary with all the [operations](#operation-object) this application MUST implement.
 
-> If you're looking for a place to define operations that MAY or MAY NOT be implemented by the application, consider defining them in [`components/operations`](#componentsOperations).
+> If you're looking for a place to define operations that MAY or MAY NOT be implemented by the application, consider defining them in [`components/operations`](#components-operations).
 
 ##### Patterned Fields
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="operationsObjectOperation"></a>{operationId} | [Operation Object](#operationObject) \| [Reference Object](#referenceObject) | The operation this application MUST implement. The field name (`operationId`) MUST be a string used to identify the operation in the document where it is defined, and its value is **case-sensitive**. Tools and libraries MAY use the `operationId` to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="operations-object-operation"></a>{operationId} | [Operation Object](#operation-object) \| [Reference Object](#reference-object) | The operation this application MUST implement. The field name (`operationId`) MUST be a string used to identify the operation in the document where it is defined, and its value is **case-sensitive**. Tools and libraries MAY use the `operationId` to uniquely identify an operation, therefore, it is RECOMMENDED to follow common programming naming conventions.
 
 ##### Operations Object Example
 
@@ -828,7 +828,7 @@ onUserSignUp:
     - $ref: '#/components/operationTraits/kafka'
 ```
 
-#### <a name="operationObject"></a>Operation Object
+#### <a name="operation-object"></a>Operation Object
 
 Describes a specific operation.
 
@@ -836,20 +836,20 @@ Describes a specific operation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationObjectAction"></a>action | `"send"` &#124; `"receive"` | **Required**. Use `send` when it's expected that the application will send a message to the given [`channel`](#operationObjectChannel), and `receive` when the application should expect receiving messages from the given [`channel`](#operationObjectChannel).
-<a name="operationObjectChannel"></a>channel | [Reference Object](#referenceObject) | **Required**. A `$ref` pointer to the definition of the channel in which this operation is performed. If the operation is located in the [root Operations Object](#operationsObject), it MUST point to a channel definition located in the [root Channels Object](#channelsObject), and MUST NOT point to a channel definition located in the [Components Object](#componentsObject) or anywhere else. If the operation is located in the [Components Object](#componentsObject), it MAY point to a [Channel Object](#channelObject) in any location. Please note the `channel` property value MUST be a [Reference Object](#referenceObject) and, therefore, MUST NOT contain a [Channel Object](#channelObject). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
-<a name="operationObjectTitle"></a>title | `string` | A human-friendly title for the operation.
-<a name="operationObjectSummary"></a>summary | `string` | A short summary of what the operation is about.
-<a name="operationObjectDescription"></a>description | `string` | A verbose explanation of the operation. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
-<a name="operationObjectSecurity"></a>security | [[Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)]| A declaration of which security schemes are associated with this operation. Only one of the [security scheme objects](#securitySchemeObject) MUST be satisfied to authorize an operation. In cases where [Server Security](#serverObjectSecurity) also applies, it MUST also be satisfied.
-<a name="operationObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping and categorization of operations.
-<a name="operationObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this operation.
-<a name="operationObjectBindings"></a>bindings | [Operation Bindings Object](#operationBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
-<a name="operationObjectTraits"></a>traits | [[Operation Trait Object](#operationTraitObject) &#124; [Reference Object](#referenceObject) ] | A list of traits to apply to the operation object. Traits MUST be merged using [traits merge mechanism](#traits-merge-mechanism). The resulting object MUST be a valid [Operation Object](#operationObject).
-<a name="operationObjectMessages"></a>messages | [[Reference Object](#referenceObject)] | A list of `$ref` pointers pointing to the supported [Message Objects](#messageObject) that can be processed by this operation. It MUST contain a subset of the messages defined in the [channel referenced in this operation](#operationObjectChannel), and MUST NOT point to a subset of message definitions located in the [Messages Object](#componentsMessages) in the [Components Object](#componentsObject) or anywhere else. **Every message processed by this operation MUST be valid against one, and only one, of the [message objects](#messageObject) referenced in this list.** Please note the `messages` property value MUST be a list of [Reference Objects](#referenceObject) and, therefore, MUST NOT contain [Message Objects](#messageObject). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience. <p>**Note**: excluding this property from the Operation implies that all messages from the channel will be included. Explicitly set the `messages` property to `[]` if this operation should contain no messages.</p>
-<a name="operationObjectReply"></a>reply | [Operation Reply Object](#operationReplyObject) &#124; [Reference Object](#referenceObject)  | The definition of the reply in a request-reply operation.
+<a name="operation-object-action"></a>action | `"send"` &#124; `"receive"` | **Required**. Use `send` when it's expected that the application will send a message to the given [`channel`](#operation-object-channel), and `receive` when the application should expect receiving messages from the given [`channel`](#operation-object-channel).
+<a name="operation-object-channel"></a>channel | [Reference Object](#reference-object) | **Required**. A `$ref` pointer to the definition of the channel in which this operation is performed. If the operation is located in the [root Operations Object](#operations-object), it MUST point to a channel definition located in the [root Channels Object](#channels-object), and MUST NOT point to a channel definition located in the [Components Object](#components-object) or anywhere else. If the operation is located in the [Components Object](#components-object), it MAY point to a [Channel Object](#channel-object) in any location. Please note the `channel` property value MUST be a [Reference Object](#reference-object) and, therefore, MUST NOT contain a [Channel Object](#channel-object). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
+<a name="operation-object-title"></a>title | `string` | A human-friendly title for the operation.
+<a name="operation-object-summary"></a>summary | `string` | A short summary of what the operation is about.
+<a name="operation-object-description"></a>description | `string` | A verbose explanation of the operation. [CommonMark syntax](http://spec.commonmark.org/) can be used for rich text representation.
+<a name="operation-object-security"></a>security | [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)| A declaration of which security schemes are associated with this operation. Only one of the [security scheme objects](#security-scheme-object) MUST be satisfied to authorize an operation. In cases where [Server Security](#server-object-security) also applies, it MUST also be satisfied.
+<a name="operation-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping and categorization of operations.
+<a name="operation-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this operation.
+<a name="operation-object-bindings"></a>bindings | [Operation Bindings Object](#operation-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
+<a name="operation-object-traits"></a>traits | [[Operation Trait Object](#operation-trait-object) &#124; [Reference Object](#reference-object) ] | A list of traits to apply to the operation object. Traits MUST be merged using [traits merge mechanism](#traits-merge-mechanism). The resulting object MUST be a valid [Operation Object](#operation-object).
+<a name="operation-object-messages"></a>messages | [[Reference Object](#reference-object)] | A list of `$ref` pointers pointing to the supported [Message Objects](#message-object) that can be processed by this operation. It MUST contain a subset of the messages defined in the [channel referenced in this operation](#operation-object-channel), and MUST NOT point to a subset of message definitions located in the [Messages Object](#components-messages) in the [Components Object](#components-object) or anywhere else. **Every message processed by this operation MUST be valid against one, and only one, of the [message objects](#message-object) referenced in this list.** Please note the `messages` property value MUST be a list of [Reference Objects](#reference-object) and, therefore, MUST NOT contain [Message Objects](#message-object). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience. <p>**Note**: excluding this property from the Operation implies that all messages from the channel will be included. Explicitly set the `messages` property to `[]` if this operation should contain no messages.</p>
+<a name="operation-object-reply"></a>reply | [Operation Reply Object](#operation-reply-object) &#124; [Reference Object](#reference-object)  | The definition of the reply in a request-reply operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Object Example
 
@@ -955,25 +955,25 @@ reply:
     - $ref: '#/channels/userSignupReply/messages/userSignedUpReply'
 ```
 
-#### <a name="operationTraitObject"></a>Operation Trait Object
+#### <a name="operation-trait-object"></a>Operation Trait Object
 
-Describes a trait that MAY be applied to an [Operation Object](#operationObject). This object MAY contain any property from the [Operation Object](#operationObject), except the `action`, `channel`, `messages` and `traits` ones.
+Describes a trait that MAY be applied to an [Operation Object](#operation-object). This object MAY contain any property from the [Operation Object](#operation-object), except the `action`, `channel`, `messages` and `traits` ones.
 
-If you're looking to apply traits to a message, see the [Message Trait Object](#messageTraitObject).
+If you're looking to apply traits to a message, see the [Message Trait Object](#message-trait-object).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationTraitObjectTitle"></a>title | `string` | A human-friendly title for the operation.
-<a name="operationTraitObjectSummary"></a>summary | `string` | A short summary of what the operation is about.
-<a name="operationTraitObjectDescription"></a>description | `string` | A verbose explanation of the operation. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="operationTraitObjectSecurity"></a>security | [[Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)]| A declaration of which security schemes are associated with this operation. Only one of the [security scheme objects](#securitySchemeObject) MUST be satisfied to authorize an operation. In cases where [Server Security](#serverObjectSecurity) also applies, it MUST also be satisfied.
-<a name="operationTraitObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping and categorization of operations.
-<a name="operationTraitObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this operation.
-<a name="operationTraitObjectBindings"></a>bindings | [Operation Bindings Object](#operationBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
+<a name="operation-trait-object-title"></a>title | `string` | A human-friendly title for the operation.
+<a name="operation-trait-object-summary"></a>summary | `string` | A short summary of what the operation is about.
+<a name="operation-trait-object-description"></a>description | `string` | A verbose explanation of the operation. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="operation-trait-object-security"></a>security | [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)| A declaration of which security schemes are associated with this operation. Only one of the [security scheme objects](#security-scheme-object) MUST be satisfied to authorize an operation. In cases where [Server Security](#server-object-security) also applies, it MUST also be satisfied.
+<a name="operation-trait-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping and categorization of operations.
+<a name="operation-trait-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this operation.
+<a name="operation-trait-object-bindings"></a>bindings | [Operation Bindings Object](#operation-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Operation Trait Object Example
 
@@ -995,7 +995,7 @@ bindings:
     ack: false
 ```
 
-#### <a name="operationReplyObject"></a>Operation Reply Object
+#### <a name="operation-reply-object"></a>Operation Reply Object
 
 Describes the reply part that MAY be applied to an Operation Object. If an operation implements the request/reply pattern, the reply object represents the response message.
 
@@ -1003,26 +1003,26 @@ Describes the reply part that MAY be applied to an Operation Object. If an opera
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationReplyObjectAddress"></a>address | [Operation Reply Address Object](#operationReplyAddressObject) &#124; [Reference Object](#referenceObject) | Definition of the address that implementations MUST use for the reply.
-<a name="operationReplyObjectChannel"></a>channel | [Reference Object](#referenceObject) | A `$ref` pointer to the definition of the channel in which this operation is performed. When [address](#operationReplyAddressObject) is specified, the [`address` property](#channelObjectAddress) of the channel referenced by this property MUST be either `null` or not defined. If the operation reply is located inside a [root Operation Object](#operationObject), it MUST point to a channel definition located in the [root Channels Object](#channelsObject), and MUST NOT point to a channel definition located in the [Components Object](#componentsObject) or anywhere else. If the operation reply is located inside an [Operation Object] in the [Components Object](#componentsObject) or in the [Replies Object](#componentsReplies) in the [Components Object](#componentsObject), it MAY point to a [Channel Object](#channelObject) in any location. Please note the `channel` property value MUST be a [Reference Object](#referenceObject) and, therefore, MUST NOT contain a [Channel Object](#channelObject). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
-<a name="operationReplyObjectMessages"></a>messages | [[Reference Object](#referenceObject)] | A list of `$ref` pointers pointing to the supported [Message Objects](#messageObject) that can be processed by this operation as reply. It MUST contain a subset of the messages defined in the [channel referenced in this operation reply](#operationObjectChannel), and MUST NOT point to a subset of message definitions located in the [Components Object](#componentsObject) or anywhere else. **Every message processed by this operation MUST be valid against one, and only one, of the [message objects](#messageObject) referenced in this list.** Please note the `messages` property value MUST be a list of [Reference Objects](#referenceObject) and, therefore, MUST NOT contain [Message Objects](#messageObject). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
+<a name="operation-reply-object-address"></a>address | [Operation Reply Address Object](#operation-reply-address-object) &#124; [Reference Object](#reference-object) | Definition of the address that implementations MUST use for the reply.
+<a name="operation-reply-object-channel"></a>channel | [Reference Object](#reference-object) | A `$ref` pointer to the definition of the channel in which this operation is performed. When [address](#operation-reply-address-object) is specified, the [`address` property](#channel-object-address) of the channel referenced by this property MUST be either `null` or not defined. If the operation reply is located inside a [root Operation Object](#operation-object), it MUST point to a channel definition located in the [root Channels Object](#channels-object), and MUST NOT point to a channel definition located in the [Components Object](#components-object) or anywhere else. If the operation reply is located inside an [Operation Object] in the [Components Object](#components-object) or in the [Replies Object](#components-replies) in the [Components Object](#components-object), it MAY point to a [Channel Object](#channel-object) in any location. Please note the `channel` property value MUST be a [Reference Object](#reference-object) and, therefore, MUST NOT contain a [Channel Object](#channel-object). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
+<a name="operation-reply-object-messages"></a>messages | [Reference Object](#reference-object) | A list of `$ref` pointers pointing to the supported [Message Objects](#message-object) that can be processed by this operation as reply. It MUST contain a subset of the messages defined in the [channel referenced in this operation reply](#operation-object-channel), and MUST NOT point to a subset of message definitions located in the [Components Object](#components-object) or anywhere else. **Every message processed by this operation MUST be valid against one, and only one, of the [message objects](#message-object) referenced in this list.** Please note the `messages` property value MUST be a list of [Reference Objects](#reference-object) and, therefore, MUST NOT contain [Message Objects](#message-object). However, it is RECOMMENDED that parsers (or other software) dereference this property for a better development experience.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="operationReplyAddressObject"></a>Operation Reply Address Object
+#### <a name="operation-reply-address-object"></a>Operation Reply Address Object
 
 An object that specifies where an operation has to send the reply.
 
-For specifying and computing the location of a reply address, a [runtime expression](#runtimeExpression) is used.
+For specifying and computing the location of a reply address, a [runtime expression](#runtime-expression) is used.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---|---
 description | `string` | An optional description of the address. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-location | `string` | **REQUIRED.** A [runtime expression](#runtimeExpression) that specifies the location of the reply address.
+location | `string` | **REQUIRED.** A [runtime expression](#runtime-expression) that specifies the location of the reply address.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Examples
 
@@ -1040,7 +1040,7 @@ description: Consumer Inbox
 location: $message.header#/replyTo
 ```
 
-#### <a name="parametersObject"></a>Parameters Object
+#### <a name="parameters-object"></a>Parameters Object
 
 Describes a map of parameters included in a channel address.
 
@@ -1050,7 +1050,7 @@ This map MUST contain all the parameters used in the parent channel address.
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="parametersObjectName"></a>`^[A-Za-z0-9_\-]+$` | [Parameter Object](#parameterObject) &#124; [Reference Object](#referenceObject) | The key represents the name of the parameter. It MUST match the parameter name used in the parent channel address.
+<a name="parameters-object-name"></a>`^[A-Za-z0-9_\-]+$` | [Parameter Object](#parameter-object) &#124; [Reference Object](#reference-object) | The key represents the name of the parameter. It MUST match the parameter name used in the parent channel address.
 
 ##### Parameters Object Example
 
@@ -1074,7 +1074,7 @@ parameters:
     description: Id of the user.
 ```
 
-#### <a name="parameterObject"></a>Parameter Object
+#### <a name="parameter-object"></a>Parameter Object
 
 Describes a parameter included in a channel address.
 
@@ -1082,13 +1082,13 @@ Describes a parameter included in a channel address.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="parameterObjectEnum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
-<a name="parameterObjectDefault"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
-<a name="parameterObjectDescription"></a>description | `string` | An optional description for the parameter. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="parameterObjectExamples"></a>examples | [`string`] | An array of examples of the parameter value.
-<a name="parameterObjectLocation"></a>location | `string` | A [runtime expression](#runtimeExpression) that specifies the location of the parameter value.
+<a name="parameter-object-enum"></a>enum | [`string`] | An enumeration of string values to be used if the substitution options are from a limited set.
+<a name="parameter-object-default"></a>default | `string` | The default value to use for substitution, and to send, if an alternate value is _not_ supplied.
+<a name="parameter-object-description"></a>description | `string` | An optional description for the parameter. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="parameter-object-examples"></a>examples | [`string`] | An array of examples of the parameter value.
+<a name="parameter-object-location"></a>location | `string` | A [runtime expression](#runtime-expression) that specifies the location of the parameter value.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Parameter Object Example
 
@@ -1114,7 +1114,7 @@ parameters:
     location: $message.payload#/user/id
 ```
 
-#### <a name="serverBindingsObject"></a>Server Bindings Object
+#### <a name="server-bindings-object"></a>Server Bindings Object
 
 Map describing protocol-specific definitions for a server.
 
@@ -1122,29 +1122,29 @@ Map describing protocol-specific definitions for a server.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="serverBindingsObjectHTTP"></a>`http` | [HTTP Server Binding](https://github.com/asyncapi/bindings/blob/master/http#server) | Protocol-specific information for an HTTP server.
-<a name="serverBindingsObjectWebSockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/websockets#server) | Protocol-specific information for a WebSockets server.
-<a name="serverBindingsObjectKafka"></a>`kafka` | [Kafka Server Binding](https://github.com/asyncapi/bindings/blob/master/kafka#server) | Protocol-specific information for a Kafka server.
-<a name="serverBindingsObjectAnypointMQ"></a>`anypointmq` | [Anypoint MQ Server Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq#server) | Protocol-specific information for an Anypoint MQ server.
-<a name="serverBindingsObjectAMQP"></a>`amqp` | [AMQP Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp#server) | Protocol-specific information for an AMQP 0-9-1 server.
-<a name="serverBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp1#server) | Protocol-specific information for an AMQP 1.0 server.
-<a name="serverBindingsObjectMQTT"></a>`mqtt` | [MQTT Server Binding](https://github.com/asyncapi/bindings/blob/master/mqtt#server) | Protocol-specific information for an MQTT server.
-<a name="serverBindingsObjectMQTT5"></a>`mqtt5` | [MQTT 5 Server Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5#server) | Protocol-specific information for an MQTT 5 server.
-<a name="serverBindingsObjectNATS"></a>`nats` | [NATS Server Binding](https://github.com/asyncapi/bindings/blob/master/nats#server) | Protocol-specific information for a NATS server.
-<a name="serverBindingsObjectJMS"></a>`jms` | [JMS Server Binding](https://github.com/asyncapi/bindings/blob/master/jms#server) | Protocol-specific information for a JMS server.
-<a name="serverBindingsObjectSNS"></a>`sns` | [SNS Server Binding](https://github.com/asyncapi/bindings/blob/master/sns#server) | Protocol-specific information for an SNS server.
-<a name="serverBindingsObjectSolace"></a>`solace` | [Solace Server Binding](https://github.com/asyncapi/bindings/blob/master/solace#server) | Protocol-specific information for a Solace server.
-<a name="serverBindingsObjectSQS"></a>`sqs` | [SQS Server Binding](https://github.com/asyncapi/bindings/blob/master/sqs#server) | Protocol-specific information for an SQS server.
-<a name="serverBindingsObjectSTOMP"></a>`stomp` | [STOMP Server Binding](https://github.com/asyncapi/bindings/blob/master/stomp#server) | Protocol-specific information for a STOMP server.
-<a name="serverBindingsObjectRedis"></a>`redis` | [Redis Server Binding](https://github.com/asyncapi/bindings/blob/master/redis#server) | Protocol-specific information for a Redis server.
-<a name="serverBindingsObjectMercure"></a>`mercure` | [Mercure Server Binding](https://github.com/asyncapi/bindings/blob/master/mercure#server) | Protocol-specific information for a Mercure server.
-<a name="serverBindingsObjectIBMMQ"></a>`ibmmq` | [IBM MQ Server Binding](https://github.com/asyncapi/bindings/blob/master/ibmmq#server-binding-object) | Protocol-specific information for an IBM MQ server.
-<a name="serverBindingsObjectGooglePubSub"></a>`googlepubsub` | [Google Cloud Pub/Sub Server Binding](https://github.com/asyncapi/bindings/blob/master/googlepubsub#server) | Protocol-specific information for a Google Cloud Pub/Sub server.
-<a name="serverBindingsObjectPulsar"></a>`pulsar` | [Pulsar Server Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#server-binding-object) | Protocol-specific information for a Pulsar server.
+<a name="server-bindings-object-http"></a>`http` | [HTTP Server Binding](https://github.com/asyncapi/bindings/blob/master/http#server) | Protocol-specific information for an HTTP server.
+<a name="server-bindings-object-web-sockets"></a>`ws` | [WebSockets Server Binding](https://github.com/asyncapi/bindings/blob/master/websockets#server) | Protocol-specific information for a WebSockets server.
+<a name="server-bindings-object-kafka"></a>`kafka` | [Kafka Server Binding](https://github.com/asyncapi/bindings/blob/master/kafka#server) | Protocol-specific information for a Kafka server.
+<a name="server-bindings-object-anypoint-mq"></a>`anypointmq` | [Anypoint MQ Server Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq#server) | Protocol-specific information for an Anypoint MQ server.
+<a name="server-bindings-object-amqp"></a>`amqp` | [AMQP Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp#server) | Protocol-specific information for an AMQP 0-9-1 server.
+<a name="server-bindings-object-amqp1"></a>`amqp1` | [AMQP 1.0 Server Binding](https://github.com/asyncapi/bindings/blob/master/amqp1#server) | Protocol-specific information for an AMQP 1.0 server.
+<a name="server-bindings-object-mqtt"></a>`mqtt` | [MQTT Server Binding](https://github.com/asyncapi/bindings/blob/master/mqtt#server) | Protocol-specific information for an MQTT server.
+<a name="server-bindings-object-mqtt5"></a>`mqtt5` | [MQTT 5 Server Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5#server) | Protocol-specific information for an MQTT 5 server.
+<a name="server-bindings-object-nats"></a>`nats` | [NATS Server Binding](https://github.com/asyncapi/bindings/blob/master/nats#server) | Protocol-specific information for a NATS server.
+<a name="server-bindings-object-jms"></a>`jms` | [JMS Server Binding](https://github.com/asyncapi/bindings/blob/master/jms#server) | Protocol-specific information for a JMS server.
+<a name="server-bindings-object-sns"></a>`sns` | [SNS Server Binding](https://github.com/asyncapi/bindings/blob/master/sns#server) | Protocol-specific information for an SNS server.
+<a name="server-bindings-object-solace"></a>`solace` | [Solace Server Binding](https://github.com/asyncapi/bindings/blob/master/solace#server) | Protocol-specific information for a Solace server.
+<a name="server-bindings-object-sqs"></a>`sqs` | [SQS Server Binding](https://github.com/asyncapi/bindings/blob/master/sqs#server) | Protocol-specific information for an SQS server.
+<a name="server-bindings-object-stomp"></a>`stomp` | [STOMP Server Binding](https://github.com/asyncapi/bindings/blob/master/stomp#server) | Protocol-specific information for a STOMP server.
+<a name="server-bindings-object-redis"></a>`redis` | [Redis Server Binding](https://github.com/asyncapi/bindings/blob/master/redis#server) | Protocol-specific information for a Redis server.
+<a name="server-bindings-object-mercure"></a>`mercure` | [Mercure Server Binding](https://github.com/asyncapi/bindings/blob/master/mercure#server) | Protocol-specific information for a Mercure server.
+<a name="server-bindings-object-ibmmq"></a>`ibmmq` | [IBM MQ Server Binding](https://github.com/asyncapi/bindings/blob/master/ibmmq#server-binding-object) | Protocol-specific information for an IBM MQ server.
+<a name="server-bindings-object-google-pub-sub"></a>`googlepubsub` | [Google Cloud Pub/Sub Server Binding](https://github.com/asyncapi/bindings/blob/master/googlepubsub#server) | Protocol-specific information for a Google Cloud Pub/Sub server.
+<a name="server-bindings-object-pulsar"></a>`pulsar` | [Pulsar Server Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#server-binding-object) | Protocol-specific information for a Pulsar server.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="channelBindingsObject"></a>Channel Bindings Object
+#### <a name="channel-bindings-object"></a>Channel Bindings Object
 
 Map describing protocol-specific definitions for a channel.
 
@@ -1152,29 +1152,29 @@ Map describing protocol-specific definitions for a channel.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="channelBindingsObjectHTTP"></a>`http` | [HTTP Channel Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#channel) | Protocol-specific information for an HTTP channel.
-<a name="channelBindingsObjectWebSockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#channel) | Protocol-specific information for a WebSockets channel.
-<a name="channelBindingsObjectKafka"></a>`kafka` | [Kafka Channel Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#channel) | Protocol-specific information for a Kafka channel.
-<a name="channelBindingsObjectAnypointMQ"></a>`anypointmq` | [Anypoint MQ Channel Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#channel) | Protocol-specific information for an Anypoint MQ channel.
-<a name="channelBindingsObjectAMQP"></a>`amqp` | [AMQP Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#channel) | Protocol-specific information for an AMQP 0-9-1 channel.
-<a name="channelBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#channel) | Protocol-specific information for an AMQP 1.0 channel.
-<a name="channelBindingsObjectMQTT"></a>`mqtt` | [MQTT Channel Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#channel) | Protocol-specific information for an MQTT channel.
-<a name="channelBindingsObjectMQTT5"></a>`mqtt5` | [MQTT 5 Channel Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5#channel) | Protocol-specific information for an MQTT 5 channel.
-<a name="channelBindingsObjectNATS"></a>`nats` | [NATS Channel Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#channel) | Protocol-specific information for a NATS channel.
-<a name="channelBindingsObjectJMS"></a>`jms` | [JMS Channel Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#channel) | Protocol-specific information for a JMS channel.
-<a name="channelBindingsObjectSNS"></a>`sns` | [SNS Channel Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#channel) | Protocol-specific information for an SNS channel.
-<a name="channelBindingsObjectSolace"></a>`solace` | [Solace Channel Binding](https://github.com/asyncapi/bindings/blob/master/solace#channel) | Protocol-specific information for a Solace channel.
-<a name="channelBindingsObjectSQS"></a>`sqs` | [SQS Channel Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#channel) | Protocol-specific information for an SQS channel.
-<a name="channelBindingsObjectSTOMP"></a>`stomp` | [STOMP Channel Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#channel) | Protocol-specific information for a STOMP channel.
-<a name="channelBindingsObjectRedis"></a>`redis` | [Redis Channel Binding](https://github.com/asyncapi/bindings/blob/master/redis#channel) | Protocol-specific information for a Redis channel.
-<a name="channelBindingsObjectMercure"></a>`mercure` | [Mercure Channel Binding](https://github.com/asyncapi/bindings/blob/master/mercure#channel) | Protocol-specific information for a Mercure channel.
-<a name="channelBindingsObjectIBMMQ"></a>`ibmmq` | [IBM MQ Channel Binding](https://github.com/asyncapi/bindings/tree/master/ibmmq#channel-binding-object) | Protocol-specific information for an IBM MQ channel.
-<a name="channelBindingsObjectGooglePubSub"></a>`googlepubsub` | [Google Cloud Pub/Sub Channel Binding](https://github.com/asyncapi/bindings/tree/master/googlepubsub#channel) | Protocol-specific information for a Google Cloud Pub/Sub channel.
-<a name="channelBindingsObjectPulsar"></a>`pulsar` | [Pulsar Channel Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#channel-binding-object) | Protocol-specific information for a Pulsar channel.
+<a name="channel-bindings-object-http"></a>`http` | [HTTP Channel Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#channel) | Protocol-specific information for an HTTP channel.
+<a name="channel-bindings-object-web-sockets"></a>`ws` | [WebSockets Channel Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#channel) | Protocol-specific information for a WebSockets channel.
+<a name="channel-bindings-object-kafka"></a>`kafka` | [Kafka Channel Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#channel) | Protocol-specific information for a Kafka channel.
+<a name="channel-bindings-object-anypoint-mq"></a>`anypointmq` | [Anypoint MQ Channel Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#channel) | Protocol-specific information for an Anypoint MQ channel.
+<a name="channel-bindings-object-amqp"></a>`amqp` | [AMQP Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#channel) | Protocol-specific information for an AMQP 0-9-1 channel.
+<a name="channel-bindings-object-amqp1"></a>`amqp1` | [AMQP 1.0 Channel Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#channel) | Protocol-specific information for an AMQP 1.0 channel.
+<a name="channel-bindings-object-mqtt"></a>`mqtt` | [MQTT Channel Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#channel) | Protocol-specific information for an MQTT channel.
+<a name="channel-bindings-object-mqtt5"></a>`mqtt5` | [MQTT 5 Channel Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5#channel) | Protocol-specific information for an MQTT 5 channel.
+<a name="channel-bindings-object-nats"></a>`nats` | [NATS Channel Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#channel) | Protocol-specific information for a NATS channel.
+<a name="channel-bindings-object-jms"></a>`jms` | [JMS Channel Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#channel) | Protocol-specific information for a JMS channel.
+<a name="channel-bindings-object-sns"></a>`sns` | [SNS Channel Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#channel) | Protocol-specific information for an SNS channel.
+<a name="channel-bindings-object-solace"></a>`solace` | [Solace Channel Binding](https://github.com/asyncapi/bindings/blob/master/solace#channel) | Protocol-specific information for a Solace channel.
+<a name="channel-bindings-object-sqs"></a>`sqs` | [SQS Channel Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#channel) | Protocol-specific information for an SQS channel.
+<a name="channel-bindings-object-stomp"></a>`stomp` | [STOMP Channel Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#channel) | Protocol-specific information for a STOMP channel.
+<a name="channel-bindings-object-redis"></a>`redis` | [Redis Channel Binding](https://github.com/asyncapi/bindings/blob/master/redis#channel) | Protocol-specific information for a Redis channel.
+<a name="channel-bindings-object-mercure"></a>`mercure` | [Mercure Channel Binding](https://github.com/asyncapi/bindings/blob/master/mercure#channel) | Protocol-specific information for a Mercure channel.
+<a name="channel-bindings-object-ibmmq"></a>`ibmmq` | [IBM MQ Channel Binding](https://github.com/asyncapi/bindings/tree/master/ibmmq#channel-binding-object) | Protocol-specific information for an IBM MQ channel.
+<a name="channel-bindings-object-google-pub-sub"></a>`googlepubsub` | [Google Cloud Pub/Sub Channel Binding](https://github.com/asyncapi/bindings/tree/master/googlepubsub#channel) | Protocol-specific information for a Google Cloud Pub/Sub channel.
+<a name="channel-bindings-object-pulsar"></a>`pulsar` | [Pulsar Channel Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#channel-binding-object) | Protocol-specific information for a Pulsar channel.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="operationBindingsObject"></a>Operation Bindings Object
+#### <a name="operation-bindings-object"></a>Operation Bindings Object
 
 Map describing protocol-specific definitions for an operation.
 
@@ -1182,29 +1182,29 @@ Map describing protocol-specific definitions for an operation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="operationBindingsObjectHTTP"></a>`http` | [HTTP Operation Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#operation) | Protocol-specific information for an HTTP operation.
-<a name="operationBindingsObjectWebSockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#operation) | Protocol-specific information for a WebSockets operation.
-<a name="operationBindingsObjectKafka"></a>`kafka` | [Kafka Operation Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#operation) | Protocol-specific information for a Kafka operation.
-<a name="operationBindingsObjectAnypointMQ"></a>`anypointmq` | [Anypoint MQ Operation Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#operation) | Protocol-specific information for an Anypoint MQ operation.
-<a name="operationBindingsObjectAMQP"></a>`amqp` | [AMQP Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#operation) | Protocol-specific information for an AMQP 0-9-1 operation.
-<a name="operationBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#operation) | Protocol-specific information for an AMQP 1.0 operation.
-<a name="operationBindingsObjectMQTT"></a>`mqtt` | [MQTT Operation Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#operation) | Protocol-specific information for an MQTT operation.
-<a name="operationBindingsObjectMQTT5"></a>`mqtt5` | [MQTT 5 Operation Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5/README.md#operation) | Protocol-specific information for an MQTT 5 operation.
-<a name="operationBindingsObjectNATS"></a>`nats` | [NATS Operation Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#operation) | Protocol-specific information for a NATS operation.
-<a name="operationBindingsObjectJMS"></a>`jms` | [JMS Operation Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#operation) | Protocol-specific information for a JMS operation.
-<a name="operationBindingsObjectSNS"></a>`sns` | [SNS Operation Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#operation) | Protocol-specific information for an SNS operation.
-<a name="operationBindingsObjectSolace"></a>`solace` | [Solace Operation Binding](https://github.com/asyncapi/bindings/blob/master/solace#operation) | Protocol-specific information for a Solace operation.
-<a name="operationBindingsObjectSQS"></a>`sqs` | [SQS Operation Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#operation) | Protocol-specific information for an SQS operation.
-<a name="operationBindingsObjectSTOMP"></a>`stomp` | [STOMP Operation Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#operation) | Protocol-specific information for a STOMP operation.
-<a name="operationBindingsObjectRedis"></a>`redis` | [Redis Operation Binding](https://github.com/asyncapi/bindings/blob/master/redis#operation) | Protocol-specific information for a Redis operation.
-<a name="operationBindingsObjectMercure"></a>`mercure` | [Mercure Operation Binding](https://github.com/asyncapi/bindings/blob/master/mercure#operation) | Protocol-specific information for a Mercure operation.
-<a name="operationBindingsObjectGooglePubSub"></a>`googlepubsub` | [Google Cloud Pub/Sub Operation Binding](https://github.com/asyncapi/bindings/blob/master/googlepubsub#operation) | Protocol-specific information for a Google Cloud Pub/Sub operation.
-<a name="operationBindingsObjectIBMMQ"></a>`ibmmq` | [IBM MQ Operation Binding](https://github.com/asyncapi/bindings/blob/master/ibmmq#operation-binding-object) | Protocol-specific information for an IBM MQ operation.
-<a name="operationBindingsObjectPulsar"></a>`pulsar` | [Pulsar Operation Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#operation-binding-fields) | Protocol-specific information for a Pulsar operation.
+<a name="operation-bindings-object-http"></a>`http` | [HTTP Operation Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#operation) | Protocol-specific information for an HTTP operation.
+<a name="operation-bindings-object-web-sockets"></a>`ws` | [WebSockets Operation Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#operation) | Protocol-specific information for a WebSockets operation.
+<a name="operation-bindings-object-kafka"></a>`kafka` | [Kafka Operation Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#operation) | Protocol-specific information for a Kafka operation.
+<a name="operation-bindings-object-anypoint-mq"></a>`anypointmq` | [Anypoint MQ Operation Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#operation) | Protocol-specific information for an Anypoint MQ operation.
+<a name="operation-bindings-object-amqp"></a>`amqp` | [AMQP Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#operation) | Protocol-specific information for an AMQP 0-9-1 operation.
+<a name="operation-bindings-object-amqp1"></a>`amqp1` | [AMQP 1.0 Operation Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#operation) | Protocol-specific information for an AMQP 1.0 operation.
+<a name="operation-bindings-object-mqtt"></a>`mqtt` | [MQTT Operation Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#operation) | Protocol-specific information for an MQTT operation.
+<a name="operation-bindings-object-mqtt5"></a>`mqtt5` | [MQTT 5 Operation Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5/README.md#operation) | Protocol-specific information for an MQTT 5 operation.
+<a name="operation-bindings-object-nats"></a>`nats` | [NATS Operation Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#operation) | Protocol-specific information for a NATS operation.
+<a name="operation-bindings-object-jms"></a>`jms` | [JMS Operation Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#operation) | Protocol-specific information for a JMS operation.
+<a name="operation-bindings-object-sns"></a>`sns` | [SNS Operation Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#operation) | Protocol-specific information for an SNS operation.
+<a name="operation-bindings-object-solace"></a>`solace` | [Solace Operation Binding](https://github.com/asyncapi/bindings/blob/master/solace#operation) | Protocol-specific information for a Solace operation.
+<a name="operation-bindings-object-sqs"></a>`sqs` | [SQS Operation Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#operation) | Protocol-specific information for an SQS operation.
+<a name="operation-bindings-object-stomp"></a>`stomp` | [STOMP Operation Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#operation) | Protocol-specific information for a STOMP operation.
+<a name="operation-bindings-object-redis"></a>`redis` | [Redis Operation Binding](https://github.com/asyncapi/bindings/blob/master/redis#operation) | Protocol-specific information for a Redis operation.
+<a name="operation-bindings-object-mercure"></a>`mercure` | [Mercure Operation Binding](https://github.com/asyncapi/bindings/blob/master/mercure#operation) | Protocol-specific information for a Mercure operation.
+<a name="operation-bindings-object-google-pub-sub"></a>`googlepubsub` | [Google Cloud Pub/Sub Operation Binding](https://github.com/asyncapi/bindings/blob/master/googlepubsub#operation) | Protocol-specific information for a Google Cloud Pub/Sub operation.
+<a name="operation-bindings-object-ibmmq"></a>`ibmmq` | [IBM MQ Operation Binding](https://github.com/asyncapi/bindings/blob/master/ibmmq#operation-binding-object) | Protocol-specific information for an IBM MQ operation.
+<a name="operation-bindings-object-pulsar"></a>`pulsar` | [Pulsar Operation Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#operation-binding-fields) | Protocol-specific information for a Pulsar operation.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="messageBindingsObject"></a>Message Bindings Object
+#### <a name="message-bindings-object"></a>Message Bindings Object
 
 Map describing protocol-specific definitions for a message.
 
@@ -1212,29 +1212,29 @@ Map describing protocol-specific definitions for a message.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageBindingsObjectHTTP"></a>`http` | [HTTP Message Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#message) | Protocol-specific information for an HTTP message, i.e., a request or a response.
-<a name="messageBindingsObjectWebSockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#message) | Protocol-specific information for a WebSockets message.
-<a name="messageBindingsObjectKafka"></a>`kafka` | [Kafka Message Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#message) | Protocol-specific information for a Kafka message.
-<a name="messageBindingsObjectAnypointMQ"></a>`anypointmq` | [Anypoint MQ Message Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#message) | Protocol-specific information for an Anypoint MQ message.
-<a name="messageBindingsObjectAMQP"></a>`amqp` | [AMQP Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#message) | Protocol-specific information for an AMQP 0-9-1 message.
-<a name="messageBindingsObjectAMQP1"></a>`amqp1` | [AMQP 1.0 Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#message) | Protocol-specific information for an AMQP 1.0 message.
-<a name="messageBindingsObjectMQTT"></a>`mqtt` | [MQTT Message Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#message) | Protocol-specific information for an MQTT message.
-<a name="messageBindingsObjectMQTT5"></a>`mqtt5` | [MQTT 5 Message Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5/README.md#message) | Protocol-specific information for an MQTT 5 message.
-<a name="messageBindingsObjectNATS"></a>`nats` | [NATS Message Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#message) | Protocol-specific information for a NATS message.
-<a name="messageBindingsObjectJMS"></a>`jms` | [JMS Message Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#message) | Protocol-specific information for a JMS message.
-<a name="messageBindingsObjectSNS"></a>`sns` | [SNS Message Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#message) | Protocol-specific information for an SNS message.
-<a name="messageBindingsObjectSolace"></a>`solace` | [Solace Server Binding](https://github.com/asyncapi/bindings/blob/master/solace#message) | Protocol-specific information for a Solace message.
-<a name="messageBindingsObjectSQS"></a>`sqs` | [SQS Message Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#message) | Protocol-specific information for an SQS message.
-<a name="messageBindingsObjectSTOMP"></a>`stomp` | [STOMP Message Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#message) | Protocol-specific information for a STOMP message.
-<a name="messageBindingsObjectRedis"></a>`redis` | [Redis Message Binding](https://github.com/asyncapi/bindings/blob/master/redis#message) | Protocol-specific information for a Redis message.
-<a name="messageBindingsObjectMercure"></a>`mercure` | [Mercure Message Binding](https://github.com/asyncapi/bindings/blob/master/mercure#message) | Protocol-specific information for a Mercure message.
-<a name="messageBindingsObjectIBMMQ"></a>`ibmmq` | [IBM MQ Message Binding](https://github.com/asyncapi/bindings/tree/master/ibmmq#message-binding-object) | Protocol-specific information for an IBM MQ message.
-<a name="messageBindingsObjectGooglePubSub"></a>`googlepubsub` | [Google Cloud Pub/Sub Message Binding](https://github.com/asyncapi/bindings/tree/master/googlepubsub#message) | Protocol-specific information for a Google Cloud Pub/Sub message.
-<a name="messageBindingsObjectPulsar"></a>`pulsar` | [Pulsar Message Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#message-binding-fields) | Protocol-specific information for a Pulsar message.
+<a name="message-bindings-object-http"></a>`http` | [HTTP Message Binding](https://github.com/asyncapi/bindings/blob/master/http/README.md#message) | Protocol-specific information for an HTTP message, i.e., a request or a response.
+<a name="message-bindings-object-web-sockets"></a>`ws` | [WebSockets Message Binding](https://github.com/asyncapi/bindings/blob/master/websockets/README.md#message) | Protocol-specific information for a WebSockets message.
+<a name="message-bindings-object-kafka"></a>`kafka` | [Kafka Message Binding](https://github.com/asyncapi/bindings/blob/master/kafka/README.md#message) | Protocol-specific information for a Kafka message.
+<a name="message-bindings-object-anypoint-mq"></a>`anypointmq` | [Anypoint MQ Message Binding](https://github.com/asyncapi/bindings/blob/master/anypointmq/README.md#message) | Protocol-specific information for an Anypoint MQ message.
+<a name="message-bindings-object-amqp"></a>`amqp` | [AMQP Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp/README.md#message) | Protocol-specific information for an AMQP 0-9-1 message.
+<a name="message-bindings-objectamqp1"></a>`amqp1` | [AMQP 1.0 Message Binding](https://github.com/asyncapi/bindings/blob/master/amqp1/README.md#message) | Protocol-specific information for an AMQP 1.0 message.
+<a name="message-bindings-object-mqtt"></a>`mqtt` | [MQTT Message Binding](https://github.com/asyncapi/bindings/blob/master/mqtt/README.md#message) | Protocol-specific information for an MQTT message.
+<a name="message-bindings-object-mqtt5"></a>`mqtt5` | [MQTT 5 Message Binding](https://github.com/asyncapi/bindings/blob/master/mqtt5/README.md#message) | Protocol-specific information for an MQTT 5 message.
+<a name="message-bindings-object-nats"></a>`nats` | [NATS Message Binding](https://github.com/asyncapi/bindings/blob/master/nats/README.md#message) | Protocol-specific information for a NATS message.
+<a name="message-bindings-object-jms"></a>`jms` | [JMS Message Binding](https://github.com/asyncapi/bindings/blob/master/jms/README.md#message) | Protocol-specific information for a JMS message.
+<a name="message-bindings-object-sns"></a>`sns` | [SNS Message Binding](https://github.com/asyncapi/bindings/blob/master/sns/README.md#message) | Protocol-specific information for an SNS message.
+<a name="message-bindings-object-solace"></a>`solace` | [Solace Server Binding](https://github.com/asyncapi/bindings/blob/master/solace#message) | Protocol-specific information for a Solace message.
+<a name="message-bindings-object-sqs"></a>`sqs` | [SQS Message Binding](https://github.com/asyncapi/bindings/blob/master/sqs/README.md#message) | Protocol-specific information for an SQS message.
+<a name="message-bindings-object-stomp"></a>`stomp` | [STOMP Message Binding](https://github.com/asyncapi/bindings/blob/master/stomp/README.md#message) | Protocol-specific information for a STOMP message.
+<a name="message-bindings-object-redis"></a>`redis` | [Redis Message Binding](https://github.com/asyncapi/bindings/blob/master/redis#message) | Protocol-specific information for a Redis message.
+<a name="message-bindings-object-mercure"></a>`mercure` | [Mercure Message Binding](https://github.com/asyncapi/bindings/blob/master/mercure#message) | Protocol-specific information for a Mercure message.
+<a name="message-bindings-object-ibmmq"></a>`ibmmq` | [IBM MQ Message Binding](https://github.com/asyncapi/bindings/tree/master/ibmmq#message-binding-object) | Protocol-specific information for an IBM MQ message.
+<a name="message-bindings-object-google-pub-sub"></a>`googlepubsub` | [Google Cloud Pub/Sub Message Binding](https://github.com/asyncapi/bindings/tree/master/googlepubsub#message) | Protocol-specific information for a Google Cloud Pub/Sub message.
+<a name="message-bindings-object-pulsar"></a>`pulsar` | [Pulsar Message Binding](https://github.com/asyncapi/bindings/tree/master/pulsar#message-binding-fields) | Protocol-specific information for a Pulsar message.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="messageObject"></a>Message Object
+#### <a name="message-object"></a>Message Object
 
 Describes a message received on a given channel and operation.
 
@@ -1242,21 +1242,21 @@ Describes a message received on a given channel and operation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageObjectHeaders"></a>headers | [Multi Format Schema Object](#multiFormatSchemaObject) &#124; [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be a map of key-value pairs. It **MUST NOT** define the protocol headers. If this is a [Schema Object](#schemaObject), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#A2SVersionString).
-<a name="messageObjectPayload"></a>payload | [Multi Format Schema Object](#multiFormatSchemaObject) &#124; [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Definition of the message payload. If this is a [Schema Object](#schemaObject), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#A2SVersionString).
-<a name="messageObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
-<a name="messageObjectContentType"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#defaultContentTypeString) field.
-<a name="messageObjectName"></a>name | `string` | A machine-friendly name for the message.
-<a name="messageObjectTitle"></a>title | `string` | A human-friendly title for the message.
-<a name="messageObjectSummary"></a>summary | `string` | A short summary of what the message is about.
-<a name="messageObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="messageObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping and categorization of messages.
-<a name="messageObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this message.
-<a name="messageObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageObjectExamples"></a>examples | [[Message Example Object](#messageExampleObject)] | List of examples.
-<a name="messageObjectTraits"></a>traits | [[Message Trait Object](#messageTraitObject) &#124; [Reference Object](#referenceObject)] | A list of traits to apply to the message object. Traits MUST be merged using [traits merge mechanism](#traits-merge-mechanism). The resulting object MUST be a valid [Message Object](#messageObject).
+<a name="message-object-headers"></a>headers | [Multi Format Schema Object](#multi-format-schema-object) &#124; [Schema Object](#schema-object) &#124; [Reference Object](#reference-object) | Schema definition of the application headers. Schema MUST be a map of key-value pairs. It **MUST NOT** define the protocol headers. If this is a [Schema Object](#schema-object), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#a2s-version-string).
+<a name="message-object-payload"></a>payload | [Multi Format Schema Object](#multi-format-schema-object) &#124; [Schema Object](#schema-object) &#124; [Reference Object](#reference-object) | Definition of the message payload. If this is a [Schema Object](#schema-object), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#a2s-version-string).
+<a name="message-object-correlation-id"></a>correlationId | [Correlation ID Object](#correlation-id-object) &#124; [Reference Object](#reference-object) | Definition of the correlation ID used for message tracing or matching.
+<a name="message-object-content-type"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#default-content-type-string) field.
+<a name="message-object-name"></a>name | `string` | A machine-friendly name for the message.
+<a name="message-object-title"></a>title | `string` | A human-friendly title for the message.
+<a name="message-object-summary"></a>summary | `string` | A short summary of what the message is about.
+<a name="message-object-description"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="message-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping and categorization of messages.
+<a name="message-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this message.
+<a name="message-object-bindings"></a>bindings | [Message Bindings Object](#message-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
+<a name="message-object-examples"></a>examples | [Message Example Object](#message-example-object) | List of examples.
+<a name="message-object-traits"></a>traits | [Message Trait Object](#message-trait-object) &#124; [Reference Object](#reference-object) | A list of traits to apply to the message object. Traits MUST be merged using [traits merge mechanism](#traits-merge-mechanism). The resulting object MUST be a valid [Message Object](#message-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Message Object Example
 
@@ -1409,29 +1409,29 @@ payload:
     $ref: './user-create.avsc'
 ```
 
-#### <a name="messageTraitObject"></a>Message Trait Object
+#### <a name="message-trait-object"></a>Message Trait Object
 
-Describes a trait that MAY be applied to a [Message Object](#messageObject). This object MAY contain any property from the [Message Object](#messageObject), except `payload` and `traits`.
+Describes a trait that MAY be applied to a [Message Object](#message-object). This object MAY contain any property from the [Message Object](#message-object), except `payload` and `traits`.
 
-If you're looking to apply traits to an operation, see the [Operation Trait Object](#operationTraitObject).
+If you're looking to apply traits to an operation, see the [Operation Trait Object](#operation-trait-object).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageTraitObjectHeaders"></a>headers | [Multi Format Schema Object](#multiFormatSchemaObject) &#124; [Schema Object](#schemaObject) &#124; [Reference Object](#referenceObject) | Schema definition of the application headers. Schema MUST be a map of key-value pairs. It **MUST NOT** define the protocol headers. If this is a [Schema Object](#schemaObject), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#A2SVersionString).
-<a name="messageTraitObjectCorrelationId"></a>correlationId | [Correlation ID Object](#correlationIdObject) &#124; [Reference Object](#referenceObject) | Definition of the correlation ID used for message tracing or matching.
-<a name="messageTraitObjectContentType"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#defaultContentTypeString) field.
-<a name="messageTraitObjectName"></a>name | `string` | A machine-friendly name for the message.
-<a name="messageTraitObjectTitle"></a>title | `string` | A human-friendly title for the message.
-<a name="messageTraitObjectSummary"></a>summary | `string` | A short summary of what the message is about.
-<a name="messageTraitObjectDescription"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="messageTraitObjectTags"></a>tags | [Tags Object](#tagsObject) | A list of tags for logical grouping and categorization of messages.
-<a name="messageTraitObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this message.
-<a name="messageTraitObjectBindings"></a>bindings | [Message Bindings Object](#messageBindingsObject) \| [Reference Object](#referenceObject) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
-<a name="messageTraitObjectExamples"></a>examples | [[Message Example Object](#messageExampleObject)] | List of examples.
+<a name="message-trait-object-headers"></a>headers | [Multi Format Schema Object](#multi-format-schema-object) &#124; [Schema Object](#schema-object) &#124; [Reference Object](#reference-object) | Schema definition of the application headers. Schema MUST be a map of key-value pairs. It **MUST NOT** define the protocol headers. If this is a [Schema Object](#schema-object), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#a2s-version-string).
+<a name="message-trait-object-correlation-id"></a>correlationId | [Correlation ID Object](#correlation-id-object) &#124; [Reference Object](#reference-object) | Definition of the correlation ID used for message tracing or matching.
+<a name="message-trait-object-content-type"></a>contentType | `string` | The content type to use when encoding/decoding a message's payload. The value MUST be a specific media type (e.g. `application/json`). When omitted, the value MUST be the one specified on the [defaultContentType](#default-content-type-string) field.
+<a name="message-trait-object-name"></a>name | `string` | A machine-friendly name for the message.
+<a name="message-trait-object-title"></a>title | `string` | A human-friendly title for the message.
+<a name="message-trait-object-summary"></a>summary | `string` | A short summary of what the message is about.
+<a name="message-trait-object-description"></a>description | `string` | A verbose explanation of the message. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="message-trait-object-tags"></a>tags | [Tags Object](#tags-object) | A list of tags for logical grouping and categorization of messages.
+<a name="message-trait-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this message.
+<a name="message-trait-object-bindings"></a>bindings | [Message Bindings Object](#message-bindings-object) \| [Reference Object](#reference-object) | A map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the message.
+<a name="message-trait-object-examples"></a>examples | [Message Example Object](#message-example-object) | List of examples.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Message Trait Object Example
 
@@ -1447,20 +1447,20 @@ This object MAY be extended with [Specification Extensions](#specificationExtens
 contentType: application/json
 ```
 
-#### <a name="messageExampleObject"></a> Message Example Object
+#### <a name="message-example-object"></a> Message Example Object
 
-Message Example Object represents an example of a [Message Object](#messageObject) and MUST contain either **headers** and/or **payload** fields.
+Message Example Object represents an example of a [Message Object](#message-object) and MUST contain either **headers** and/or **payload** fields.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="messageExampleObjectHeaders"></a>headers | `Map[string, any]` | The value of this field MUST validate against the [Message Object's headers](#messageObjectHeaders) field.
-<a name="messageExampleObjectPayload"></a>payload | `any` | The value of this field MUST validate against the [Message Object's payload](#messageObjectPayload) field.
-<a name="messageExampleObjectName"></a>name | `string` | A machine-friendly name.
-<a name="messageExampleObjectSummary"></a>summary | `string` |  A short summary of what the example is about.
+<a name="message-example-object-headers"></a>headers | `Map[string, any]` | The value of this field MUST validate against the [Message Object's headers](#message-object-headers) field.
+<a name="message-example-object-payload"></a>payload | `any` | The value of this field MUST validate against the [Message Object's payload](#message-object-payload) field.
+<a name="message-example-object-name"></a>name | `string` | A machine-friendly name.
+<a name="message-example-object-summary"></a>summary | `string` |  A short summary of what the example is about.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Message Example Object Example
 
@@ -1498,11 +1498,11 @@ payload:
     someSignupKey: someSignupValue
 ```
 
-#### <a name="tagsObject"></a>Tags Object
+#### <a name="tags-object"></a>Tags Object
 
-A Tags object is a list of [Tag Objects](#tagObject). An [Tag Object](#tagObject) in a list can be referenced by [Reference Object](#referenceObject).
+A Tags object is a list of [Tag Objects](#tag-object). An [Tag Object](#tag-object) in a list can be referenced by [Reference Object](#reference-object).
 
-#### <a name="tagObject"></a>Tag Object
+#### <a name="tag-object"></a>Tag Object
 
 Allows adding meta data to a single tag.
 
@@ -1510,11 +1510,11 @@ Allows adding meta data to a single tag.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="tagObjectName"></a>name | `string` | **REQUIRED.** The name of the tag.
-<a name="tagObjectDescription"></a>description | `string` | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="tagObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this tag.
+<a name="tag-object-name"></a>name | `string` | **REQUIRED.** The name of the tag.
+<a name="tag-object-description"></a>description | `string` | A short description for the tag. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="tag-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this tag.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Tag Object Example
 
@@ -1532,7 +1532,7 @@ name: user
 description: User-related messages
 ```
 
-#### <a name="externalDocumentationObject"></a>External Documentation Object
+#### <a name="external-documentation-object"></a>External Documentation Object
 
 Allows referencing an external resource for extended documentation.
 
@@ -1540,10 +1540,10 @@ Allows referencing an external resource for extended documentation.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="externalDocDescription"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-<a name="externalDocUrl"></a>url | `string` | **REQUIRED.** The URL for the target documentation. This MUST be in the form of an absolute URL.
+<a name="external-doc-description"></a>description | `string` | A short description of the target documentation. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
+<a name="external-doc-url"></a>url | `string` | **REQUIRED.** The URL for the target documentation. This MUST be in the form of an absolute URL.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### External Documentation Object Example
 
@@ -1561,7 +1561,7 @@ description: Find more info here
 url: https://example.com
 ```
 
-#### <a name="referenceObject"></a>Reference Object
+#### <a name="reference-object"></a>Reference Object
 
 A simple object to allow referencing other components in the specification, internally and externally.
 
@@ -1573,7 +1573,7 @@ For this specification, reference resolution is done as defined by the JSON Refe
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="referenceRef"></a>$ref | `string` | **REQUIRED.** The reference string.
+<a name="reference-ref"></a>$ref | `string` | **REQUIRED.** The reference string.
 
 This object cannot be extended with additional properties and any properties added SHALL be ignored.
 
@@ -1591,7 +1591,7 @@ This object cannot be extended with additional properties and any properties add
   $ref: '#/components/schemas/Pet'
 ```
 
-#### <a name="componentsObject"></a>Components Object
+#### <a name="components-object"></a>Components Object
 
 Holds a set of reusable objects for different aspects of the AsyncAPI specification.
 All objects defined within the components object will have no effect on the API unless they are explicitly referenced from properties outside the components object.
@@ -1600,27 +1600,27 @@ All objects defined within the components object will have no effect on the API 
 
 Field Name | Type | Description
 ---|:---|---
-<a name="componentsSchemas"></a> schemas | Map[`string`, [Multi Format Schema Object](#multiFormatSchemaObject) \| [Schema Object](#schemaObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Schema Object](#schemaObject). If this is a [Schema Object](#schemaObject), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#A2SVersionString).
-<a name="componentsServers"></a> servers | Map[`string`, [Server Object](#serverObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Server Objects](#serverObject).
-<a name="componentsChannels"></a> channels | Map[`string`, [Channel Object](#channelObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Channel Objects](#channelObject).
-<a name="componentsOperations"></a> operations | Map[`string`, [Operation Object](#operationObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Operation Objects](#operationObject).
-<a name="componentsMessages"></a> messages | Map[`string`, [Message Object](#messageObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Message Objects](#messageObject).
-<a name="componentsSecuritySchemes"></a> securitySchemes| Map[`string`, [Security Scheme Object](#securitySchemeObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Security Scheme Objects](#securitySchemeObject).
-<a name="componentsServerVariables"></a> serverVariables | Map[`string`, [Server Variable Object](#serverVariableObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Server Variable Objects](#serverVariableObject).
-<a name="componentsParameters"></a> parameters | Map[`string`, [Parameter Object](#parameterObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Parameter Objects](#parameterObject).
-<a name="componentsCorrelationIDs"></a> correlationIds | Map[`string`, [Correlation ID Object](#correlationIdObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Correlation ID Objects](#correlationIdObject).
-<a name="componentsReplies"></a>replies | Map[`string`, [Operation Reply Object](#operationReplyObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Operation Reply Objects](#operationReplyObject).
-<a name="componentsReplyAddresses"></a> replyAddresses | Map[`string`, [Operation Reply Address Object](#operationReplyAddressObject) &#124; [Reference Object](#referenceObject)] | An object to hold reusable [Operation Reply Address Objects](#operationReplyAddressObject).
-<a name="componentsExternalDocs"></a> externalDocs | Map[`string`, [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [External Documentation Objects](#externalDocumentationObject).
-<a name="componentsTags"></a> tags | Map[`string`, [Tag Object](#tagObject) \| [Reference Object](#referenceObject)] | An object to hold reusable [Tag Objects](#tagObject).
-<a name="componentsOperationTraits"></a> operationTraits | Map[`string`, [Operation Trait Object](#operationTraitObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Operation Trait Objects](#operationTraitObject).
-<a name="componentsMessageTraits"></a> messageTraits | Map[`string`, [Message Trait Object](#messageTraitObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Message Trait Objects](#messageTraitObject).
-<a name="componentsServerBindings"></a> serverBindings | Map[`string`, [Server Bindings Object](#serverBindingsObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Server Bindings Objects](#serverBindingsObject).
-<a name="componentsChannelBindings"></a> channelBindings | Map[`string`, [Channel Bindings Object](#channelBindingsObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Channel Bindings Objects](#channelBindingsObject).
-<a name="componentsOperationBindings"></a> operationBindings | Map[`string`, [Operation Bindings Object](#operationBindingsObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Operation Bindings Objects](#operationBindingsObject).
-<a name="componentsMessageBindings"></a> messageBindings | Map[`string`, [Message Bindings Object](#messageBindingsObject) \| [Reference Object](#referenceObject)]  | An object to hold reusable [Message Bindings Objects](#messageBindingsObject).
+<a name="components-schemas"></a>schemas | Map[`string`, [Multi Format Schema Object](#multi-format-schema-object) \| [Schema Object](#schema-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Schema Object](#schema-object). If this is a [Schema Object](#schema-object), then the `schemaFormat` will be assumed to be "application/vnd.aai.asyncapi+json;version=`asyncapi`" where the version is equal to the [AsyncAPI Version String](#a2s-version-string).
+<a name="components-servers"></a>servers | Map[`string`, [Server Object](#server-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Server Objects](#server-object).
+<a name="components-channels"></a>channels | Map[`string`, [Channel Object](#channel-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Channel Objects](#channel-object).
+<a name="components-operations"></a>operations | Map[`string`, [Operation Object](#operation-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Operation Objects](#operation-object).
+<a name="components-messages"></a>messages | Map[`string`, [Message Object](#message-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Message Objects](#message-object).
+<a name="components-security-schemes"></a>securitySchemes| Map[`string`, [Security Scheme Object](#security-scheme-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Security Scheme Objects](#security-scheme-object).
+<a name="components-server-variables"></a>serverVariables | Map[`string`, [Server Variable Object](#server-variable-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Server Variable Objects](#server-variable-object).
+<a name="components-parameters"></a>parameters | Map[`string`, [Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Parameter Objects](#parameter-object).
+<a name="components-correlationIDs"></a>correlationIds | Map[`string`, [Correlation ID Object](#correlation-id-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Correlation ID Objects](#correlation-id-object).
+<a name="components-replies"></a>replies | Map[`string`, [Operation Reply Object](#operation-reply-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Operation Reply Objects](#operation-reply-object).
+<a name="components-reply-addresses"></a>replyAddresses | Map[`string`, [Operation Reply Address Object](#operation-reply-address-object) &#124; [Reference Object](#reference-object)] | An object to hold reusable [Operation Reply Address Objects](#operation-reply-address-object).
+<a name="components-external-docs"></a>externalDocs | Map[`string`, [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object)] | An object to hold reusable [External Documentation Objects](#external-documentation-object).
+<a name="components-tags"></a>tags | Map[`string`, [Tag Object](#tag-object) \| [Reference Object](#reference-object)] | An object to hold reusable [Tag Objects](#tag-object).
+<a name="components-operation-traits"></a>operationTraits | Map[`string`, [Operation Trait Object](#operation-trait-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Operation Trait Objects](#operation-trait-object).
+<a name="components-message-traits"></a>messageTraits | Map[`string`, [Message Trait Object](#message-trait-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Message Trait Objects](#message-trait-object).
+<a name="components-server-bindings"></a>serverBindings | Map[`string`, [Server Bindings Object](#server-bindings-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Server Bindings Objects](#server-bindings-object).
+<a name="components-channel-bindings"></a>channelBindings | Map[`string`, [Channel Bindings Object](#channel-bindings-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Channel Bindings Objects](#channel-bindings-object).
+<a name="components-operation-bindings"></a>operationBindings | Map[`string`, [Operation Bindings Object](#operation-bindings-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Operation Bindings Objects](#operation-bindings-object).
+<a name="components-message-bindings"></a>messageBindings | Map[`string`, [Message Bindings Object](#message-bindings-object) \| [Reference Object](#reference-object)]  | An object to hold reusable [Message Bindings Objects](#message-bindings-object).
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 All the fixed fields declared above are objects that MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
 
@@ -1863,26 +1863,26 @@ components:
             maximum: 100
 ```
 
-#### <a name="multiFormatSchemaObject"></a>Multi Format Schema Object
+#### <a name="multi-format-schema-object"></a>Multi Format Schema Object
 
-The Multi Format Schema Object represents a schema definition. It differs from the [Schema Object](#schemaObject) in that it supports multiple schema formats or languages (e.g., JSON Schema, Avro, etc.).
+The Multi Format Schema Object represents a schema definition. It differs from the [Schema Object](#schema-object) in that it supports multiple schema formats or languages (e.g., JSON Schema, Avro, etc.).
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="multiFormatSchemaObjectSchemaFormat"></a>schemaFormat | `string` | **Required**. A string containing the name of the schema format that is used to define the information. If `schemaFormat` is missing, it MUST default to `application/vnd.aai.asyncapi+json;version={{asyncapi}}` where `{{asyncapi}}` matches the [AsyncAPI Version String](#A2SVersionString). In such a case, this would make the Multi Format Schema Object equivalent to the [Schema Object](#schemaObject). When using [Reference Object](#referenceObject) within the schema, the `schemaFormat` of the resource being referenced MUST match the `schemaFormat` of the schema that contains the initial reference. For example, if you reference Avro `schema`, then `schemaFormat` of referencing resource and the resource being reference MUST match. <br/><br/>Check out the [supported schema formats table](#multiFormatSchemaFormatTable) for more information. Custom values are allowed but their implementation is OPTIONAL. A custom value MUST NOT refer to one of the schema formats listed in the [table](#multiFormatSchemaFormatTable).<br/><br/>When using [Reference Objects](#referenceObject) within the schema, the `schemaFormat` of the referenced resource MUST match the `schemaFormat` of the schema containing the reference.
-<a name="multiFormatSchemaObjectSchema"></a>schema | `any` | **Required**. Definition of the message payload. It can be of any type but defaults to [Schema Object](#schemaObject). It MUST match the schema format defined in [`schemaFormat`](#multiFormatSchemaObjectSchemaFormat), including the encoding type. E.g., Avro should be inlined as either a YAML or JSON object instead of as a string to be parsed as YAML or JSON. Non-JSON-based schemas (e.g., Protobuf or XSD) MUST be inlined as a string.
+<a name="multi-format-schema-object-schema-format"></a>schemaFormat | `string` | **REQUIRED**. A string containing the name of the schema format that is used to define the information. If `schemaFormat` is missing, it MUST default to `application/vnd.aai.asyncapi+json;version={{asyncapi}}` where `{{asyncapi}}` matches the [AsyncAPI Version String](#a2s-version-string). In such a case, this would make the Multi Format Schema Object equivalent to the [Schema Object](#schema-object). When using [Reference Object](#reference-object) within the schema, the `schemaFormat` of the resource being referenced MUST match the `schemaFormat` of the schema that contains the initial reference. For example, if you reference Avro `schema`, … then `schemaFormat` of the referencing resource and the resource being referenced MUST match. <br/><br/>Check out the [supported schema formats table](#multi-format-schema-format-table) for more information. Custom values are allowed but their implementation is OPTIONAL. A custom value MUST NOT refer to one of the schema formats listed in the [table](#multi-format-schema-format-table).<br/><br/>When using [Reference Objects](#reference-object) within the schema, the `schemaFormat` of the referenced resource MUST match the `schemaFormat` of the schema containing the reference.
+<a name="multi-format-schema-object-schema"></a>schema | `any` | **REQUIRED**. Definition of the message payload. It can be of any type but defaults to [Schema Object](#schema-object). It MUST match the schema format defined in [`schemaFormat`](#multi-format-schema-object-schema-format), including the encoding type. E.g., Avro should be inlined as either a YAML or JSON object instead of as a string to be parsed as YAML or JSON. Non-JSON-based schemas (e.g., Protobuf or XSD) MUST be inlined as a string.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-##### <a name="multiFormatSchemaFormatTable"></a>Schema formats table
+##### <a name="multi-format-schema-format-table"></a>Schema formats table
 
 The following table contains a set of values that every implementation MUST support.
 
 Name | Allowed values | Notes
 ---|:---:|---
-[AsyncAPI 3.0.0 Schema Object](#schemaObject) | `application/vnd.aai.asyncapi;version=3.0.0`, `application/vnd.aai.asyncapi+json;version=3.0.0`, `application/vnd.aai.asyncapi+yaml;version=3.0.0` | This is the default when a `schemaFormat` is not provided.
+[AsyncAPI 3.0.0 Schema Object](#schema-object) | `application/vnd.aai.asyncapi;version=3.0.0`, `application/vnd.aai.asyncapi+json;version=3.0.0`, `application/vnd.aai.asyncapi+yaml;version=3.0.0` | This is the default when a `schemaFormat` is not provided.
 [JSON Schema Draft 07](https://json-schema.org/specification-links.html#draft-7) | `application/schema+json;version=draft-07`, `application/schema+yaml;version=draft-07` |
 
 The following table contains a set of values that every implementation is RECOMMENDED to support.
@@ -1918,13 +1918,13 @@ channels:
                 type: int
 ```
 
-#### <a name="schemaObject"></a>Schema Object
+#### <a name="schema-object"></a>Schema Object
 
 The Schema Object allows the definition of input and output data types.
 These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 07](https://json-schema.org/). The empty schema (which allows any instance to validate) MAY be represented by the `boolean` value `true` and a schema which allows no instance to validate MAY be represented by the `boolean` value `false`.
 
 Further information about the properties can be found in [JSON Schema Core](https://tools.ietf.org/html/draft-handrews-json-schema-01) and [JSON Schema Validation](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01).
-Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here. For other formats (e.g., Avro, RAML, etc) see [Multi Format Schema Object](#multiFormatSchemaObject).
+Unless stated otherwise, the property definitions follow the JSON Schema specification as referenced here. For other formats (e.g., Avro, RAML, etc) see [Multi Format Schema Object](#multi-format-schema-object).
 
 ##### Properties
 
@@ -1967,10 +1967,10 @@ The AsyncAPI Schema Object is a JSON Schema vocabulary which extends JSON Schema
 The following properties are taken from the JSON Schema definition but their definitions were adjusted to the AsyncAPI Specification.
 
 - description - [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-- format - See [Data Type Formats](#dataTypeFormat) for further details. While relying on JSON Schema's defined formats, the AsyncAPI Specification offers a few additional predefined formats.
-- default - Use it to specify that property has a predefined value if no other value is present. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, of `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
+- format - See [Data Type Formats](#data-type-format) for further details. While relying on JSON Schema's defined formats, the AsyncAPI Specification offers a few additional predefined formats.
+- default - Use it to specify that property has a predefined value if no other value is present. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level.For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
-Alternatively, any time a Schema Object can be used, a [Reference Object](#referenceObject) can be used in its place. This allows referencing definitions in place of defining them inline. It is appropriate to clarify that the `$ref` keyword MUST follow the behavior described by [Reference Object](#referenceObject) instead of the one in [JSON Schema definition](https://json-schema.org/understanding-json-schema/structuring.html#ref).
+Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions in place of defining them inline. It is appropriate to clarify that the `$ref` keyword MUST follow the behavior described by [Reference Object](#reference-object) instead of the one in [JSON Schema definition](https://json-schema.org/understanding-json-schema/structuring.html#ref).
 
 In addition to the JSON Schema fields, the following AsyncAPI vocabulary fields MAY be used for further schema documentation:
 
@@ -1978,13 +1978,13 @@ In addition to the JSON Schema fields, the following AsyncAPI vocabulary fields 
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="schemaObjectDiscriminator"></a>discriminator | `string` | Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the `required` property list. When used, the value MUST be the name of this schema or any schema that inherits it. See [Composition and Inheritance](#schemaComposition) for more details.
-<a name="schemaObjectExternalDocs"></a>externalDocs | [External Documentation Object](#externalDocumentationObject) \| [Reference Object](#referenceObject) | Additional external documentation for this schema.
-<a name="schemaObjectDeprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
+<a name="schema-object-discriminator"></a>discriminator | `string` | Adds support for polymorphism. The discriminator is the schema property name that is used to differentiate between other schema that inherit this schema. The property name used MUST be defined at this schema and it MUST be in the `required` property list. When used, the value MUST be the name of this schema or any schema that inherits it. See [Composition and Inheritance](#schema-composition) for more details.
+<a name="schema-object-external-docs"></a>externalDocs | [External Documentation Object](#external-documentation-object) \| [Reference Object](#reference-object) | Additional external documentation for this schema.
+<a name="schema-object-deprecated"></a> deprecated | `boolean` | Specifies that a schema is deprecated and SHOULD be transitioned out of usage. Default value is `false`.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-###### <a name="schemaComposition"></a>Composition and Inheritance (Polymorphism)
+###### <a name="schema-composition"></a>Composition and Inheritance (Polymorphism)
 
 The AsyncAPI Specification allows combining and extending model definitions using the `allOf` property of JSON Schema, in effect offering model composition.
 `allOf` takes in an array of object definitions that are validated _independently_ but together compose a single object.
@@ -2399,7 +2399,7 @@ schemas:
       - color
 ```
 
-#### <a name="securitySchemeObject"></a>Security Scheme Object
+#### <a name="security-scheme-object"></a>Security Scheme Object
 
 Defines a security scheme that can be used by the operations. Supported schemes are:
 
@@ -2417,17 +2417,17 @@ Defines a security scheme that can be used by the operations. Supported schemes 
 
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
-<a name="securitySchemeObjectType"></a>type | `string` | Any | **REQUIRED**. The type of the security scheme. Valid values are `"userPassword"`, `"apiKey"`, `"X509"`, `"symmetricEncryption"`, `"asymmetricEncryption"`, `"httpApiKey"`, `"http"`, `"oauth2"`, `"openIdConnect"`, `"plain"`, `"scramSha256"`, `"scramSha512"`, and `"gssapi"`.
-<a name="securitySchemeObjectDescription"></a>description | `string` | Any | A short description for security scheme. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
-<a name="securitySchemeObjectName"></a>name | `string` | `httpApiKey` | **REQUIRED**. The name of the header, query or cookie parameter to be used.
-<a name="securitySchemeObjectIn"></a>in | `string` | `apiKey` \| `httpApiKey` | **REQUIRED**. The location of the API key. Valid values are `"user"` and `"password"` for `apiKey` and `"query"`, `"header"` or `"cookie"` for `httpApiKey`.
-<a name="securitySchemeObjectScheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
-<a name="securitySchemeObjectBearerFormat"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
-<a name="securitySchemeFlows"></a>flows | [OAuth Flows Object](#oauthFlowsObject) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
-<a name="securitySchemeOpenIdConnectUrl"></a>openIdConnectUrl | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of an absolute URL.
-<a name="securitySchemeScopes"></a>scopes | [`string`] | `oauth2` \| `openIdConnect` | List of the needed scope names. An empty array means no scopes are needed.
+<a name="security-scheme-object-type"></a>type | `string` | Any | **REQUIRED**. The type of the security scheme. Valid values are `"userPassword"`, `"apiKey"`, `"X509"`, `"symmetricEncryption"`, `"asymmetricEncryption"`, `"httpApiKey"`, `"http"`, `"oauth2"`, `"openIdConnect"`, `"plain"`, `"scramSha256"`, `"scramSha512"`, and `"gssapi"`.
+<a name="security-scheme-object-description"></a>description | `string` | Any | A short description for security scheme. [CommonMark syntax](https://spec.commonmark.org/) MAY be used for rich text representation.
+<a name="security-scheme-object-name"></a>name | `string` | `httpApiKey` | **REQUIRED**. The name of the header, query or cookie parameter to be used.
+<a name="security-scheme-object-in"></a>in | `string` | `apiKey` \| `httpApiKey` | **REQUIRED**. The location of the API key. Valid values are `"user"` and `"password"` for `apiKey` and `"query"`, `"header"` or `"cookie"` for `httpApiKey`.
+<a name="security-scheme-object-scheme"></a>scheme | `string` | `http` | **REQUIRED**. The name of the HTTP Authorization scheme to be used in the [Authorization header as defined in RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1).
+<a name="security-scheme-object-bearer-format"></a>bearerFormat | `string` | `http` (`"bearer"`) | A hint to the client to identify how the bearer token is formatted.  Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.
+<a name="security-scheme-flows"></a>flows | [OAuth Flows Object](#oauth-flows-object) | `oauth2` | **REQUIRED**. An object containing configuration information for the flow types supported.
+<a name="security-scheme-open-id-connect-url"></a>open-id-connect-url | `string` | `openIdConnect` | **REQUIRED**. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of an absolute URL.
+<a name="security-scheme-scopes"></a>scopes | [`string`] | `oauth2` \| `openIdConnect` | List of the needed scope names. An empty array means no scopes are needed.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Security Scheme Object Example
 
@@ -2589,7 +2589,7 @@ scopes:
 type: scramSha512
 ```
 
-#### <a name="oauthFlowsObject"></a>OAuth Flows Object
+#### <a name="oauth-flows-object"></a>OAuth Flows Object
 
 Allows configuration of the supported OAuth Flows.
 
@@ -2597,14 +2597,14 @@ Allows configuration of the supported OAuth Flows.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="oauthFlowsImplicit"></a>implicit| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Implicit flow.
-<a name="oauthFlowsPassword"></a>password| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Resource Owner Protected Credentials flow.
-<a name="oauthFlowsClientCredentials"></a>clientCredentials| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Client Credentials flow.
-<a name="oauthFlowsAuthorizationCode"></a>authorizationCode| [OAuth Flow Object](#oauthFlowObject) | Configuration for the OAuth Authorization Code flow.
+<a name="oauth-flows-implicit"></a>implicit| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Implicit flow.
+<a name="oauth-flows-password"></a>password| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Resource Owner Protected Credentials flow.
+<a name="oauth-flows-client-credentials"></a>clientCredentials| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Client Credentials flow.
+<a name="oauth-flows-authorization-code"></a>authorizationCode| [OAuth Flow Object](#oauth-flow-object) | Configuration for the OAuth Authorization Code flow.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
-#### <a name="oauthFlowObject"></a>OAuth Flow Object
+#### <a name="oauth-flow-object"></a>OAuth Flow Object
 
 Configuration details for a supported OAuth Flow
 
@@ -2612,12 +2612,12 @@ Configuration details for a supported OAuth Flow
 
 Field Name | Type | Applies To | Description
 ---|:---:|---|---
-<a name="oauthFlowAuthorizationUrl"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of an absolute URL.
-<a name="oauthFlowTokenUrl"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of an absolute URL.
-<a name="oauthFlowRefreshUrl"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL.
-<a name="oauthFlowScopes"></a>availableScopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
+<a name="oauth-flow-authorization-url"></a>authorizationUrl | `string` | `oauth2` (`"implicit"`, `"authorizationCode"`) | **REQUIRED**. The authorization URL to be used for this flow. This MUST be in the form of an absolute URL.
+<a name="oauth-flow-token-url"></a>tokenUrl | `string` | `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`) | **REQUIRED**. The token URL to be used for this flow. This MUST be in the form of an absolute URL.
+<a name="oauth-flow-refresh-url"></a>refreshUrl | `string` | `oauth2` | The URL to be used for obtaining refresh tokens. This MUST be in the form of an absolute URL.
+<a name="oauth-flow-scopes"></a>availableScopes | Map[`string`, `string`] | `oauth2` | **REQUIRED**. The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### OAuth Flow Object Examples
 
@@ -2641,20 +2641,19 @@ availableScopes:
   read:pets: read your pets
 ```
 
-### <a name="correlationIdObject"></a>Correlation ID Object
+### <a name="correlation-id-object"></a>Correlation ID Object
 
-An object that specifies an identifier at design time that can used for message tracing and correlation.
 
-For specifying and computing the location of a Correlation ID, a [runtime expression](#runtimeExpression) is used.
+For specifying and computing the location of a Correlation ID, a [runtime expression](#runtime-expression) is used.
 
 #### Fixed Fields
 
 Field Name | Type | Description
 ---|:---|---
 description | `string` | An optional description of the identifier. [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
-location | `string` | **REQUIRED.** A [runtime expression](#runtimeExpression) that specifies the location of the correlation ID.
+location | `string` | **REQUIRED.** A [runtime expression](#runtime-expression) that specifies the location of the correlation ID.
 
-This object MAY be extended with [Specification Extensions](#specificationExtensions).
+This object MAY be extended with [Specification Extensions](#specification-extensions).
 
 ##### Examples
 
@@ -2672,10 +2671,10 @@ description: Default Correlation ID
 location: $message.header#/correlationId
 ```
 
-### <a name="runtimeExpression"></a>Runtime Expression
+### <a name="runtime-expression"></a>Runtime Expression
 
 A runtime expression allows values to be defined based on information that will be available within the message.
-This mechanism is used by [Correlation ID Object](#correlationIdObject) and [Operation Reply Address Object](#operationReplyAddressObject).
+This mechanism is used by [Correlation ID Object](#correlation-id-object) and [Operation Reply Address Object](#operation-reply-address-object).
 
 The runtime expression is defined by the following [ABNF](https://tools.ietf.org/html/rfc5234) syntax:
 
@@ -2689,7 +2688,7 @@ The runtime expression is defined by the following [ABNF](https://tools.ietf.org
 
 The table below provides examples of runtime expressions and examples of their use in a value:
 
-#### <a name="runtimeExpressionExamples"></a>Examples
+#### <a name="runtime-expression-examples"></a>Examples
 
 Source Location | Example expression  | Notes
 ---|:---|:---|
@@ -2698,7 +2697,7 @@ Message Payload Property | `$message.payload#/messageId` | Correlation ID is set
 
 Runtime expressions preserve the type of the referenced value.
 
-### <a name="traitsMergeMechanism"></a>Traits Merge Mechanism
+### <a name="traits-merge-mechanism"></a>Traits Merge Mechanism
 
 Traits MUST be merged with the target object using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm in the same order they are defined. A property on a trait MUST NOT override the same property on the target object.
 
@@ -2724,7 +2723,7 @@ tags:
   - name: user
 ```
 
-### <a name="specificationExtensions"></a>Specification Extensions
+### <a name="specification-extensions"></a>Specification Extensions
 
 While the AsyncAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
 
@@ -2732,11 +2731,11 @@ The extensions properties are implemented as patterned fields that are always pr
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="infoExtensions"></a>`^x-[\w\d\.\x2d_]+$` | Any | Allows extensions to the AsyncAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. Can have any valid JSON format value.
+<a name="info-extensions"></a>`^x-[\w\d\.\x2d_]+$` | Any | Allows extensions to the AsyncAPI Schema. The field name MUST begin with `x-`, for example, `x-internal-id`. The value can be `null`, a primitive, an array or an object. Can have any valid JSON format value.
 
 The extensions may or may not be supported by the available tooling, but those may be extended as well to add requested support (if tools are internal or open-sourced).
 
-### <a name="dataTypeFormat"></a>Data Type Formats
+### <a name="data-type-format"></a>Data Type Formats
 
 Primitives have an optional modifier property: `format`.
 The AsyncAPI specification uses several known formats to more finely define the data type being used.
@@ -2747,7 +2746,7 @@ Tools that do not recognize a specific `format` MAY default back to the `type` a
 
 The formats defined by the AsyncAPI Specification are:
 
-Common Name | `type` | [`format`](#dataTypeFormat) | Comments
+Common Name | `type` | [`format`](#data-type-format) | Comments
 ----------- | ------ | -------- | --------
 integer | `integer` | `int32` | signed 32 bits
 long | `integer` | `int64` | signed 64 bits

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -1912,7 +1912,7 @@ The following properties are taken from the JSON Schema definition but their def
 
 - description - [CommonMark syntax](https://spec.commonmark.org/) can be used for rich text representation.
 - format - See [Data Type Formats](#data-type-format) for further details. While relying on JSON Schema's defined formats, the AsyncAPI Specification offers a few additional predefined formats.
-- default - Use it to specify that property has a predefined value if no other value is present. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level.For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
+- default - Use it to specify that property has a predefined value if no other value is present. Unlike JSON Schema, the value MUST conform to the defined type for the Schema Object defined at the same level. For example, if `type` is `string`, then `default` can be `"foo"` but cannot be `1`.
 
 Alternatively, any time a Schema Object can be used, a [Reference Object](#reference-object) can be used in its place. This allows referencing definitions in place of defining them inline. It is appropriate to clarify that the `$ref` keyword MUST follow the behavior described by [Reference Object](#reference-object) instead of the one in [JSON Schema definition](https://json-schema.org/understanding-json-schema/structuring.html#ref).
 

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -59,62 +59,6 @@ operations:
 
 Aside from the issues mentioned above, there may also be infrastructure configuration that is not represented here. For instance, a system may use a read-only channel for receiving messages, a different one for sending them, and an intermediary process that will forward messages from one channel to the other.
 
-## Table of Contents
-<!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
-
-- [Definitions](#definitions)
-  - [Server](#definitions-server)
-  - [Application](#definitions-application)
-  - [Sender](#definitions-sender)
-  - [Receiver](#definitions-receiver)
-  - [Message](#definitions-message)
-  - [Channel](#definitions-channel)
-  - [Protocol](#definitions-protocol)
-- [Specification](#specification)
-  - [Format](#format)
-  - [File Structure](#file-structure)
-  - [Absolute URLs](#absolute-urls)
-  - [Schema](#schema)
-    - [AsyncAPI Object](#a2s-object)
-    - [AsyncAPI Version String](#a2s-version-string)
-    - [Identifier](#a2s-id-string)
-    - [Info Object](#info-object)
-    - [Contact Object](#contact-object)
-    - [License Object](#license-object)
-    - [Servers Object](#servers-object)
-    - [Server Object](#server-object)
-    - [Server Variable Object](#server-variable-object)
-    - [Default Content Type](#default-content-type-string)
-    - [Channels Object](#channels-object)
-    - [Channel Object](#channel-object)
-    - [Operations Object](#operations-object)
-    - [Operation Object](#operation-object)
-    - [Operation Trait Object](#operation-trait-object)
-    - [Operation Reply Object](#operation-reply-object)
-    - [Operation Reply Address Object](#operation-reply-address-object)
-    - [Message Object](#message-object)
-    - [Message Trait Object](#message-trait-object)
-    - [Message Example Object](#message-example-object)
-    - [Tags Object](#tags-object)
-    - [Tag Object](#tag-object)
-    - [External Documentation Object](#external-documentation-object)
-    - [Components Object](#components-object)
-    - [Reference Object](#reference-object)
-    - [Multi Format Schema Object](#multi-format-schema-object)
-    - [Schema Object](#schema-object)
-    - [Security Scheme Object](#security-scheme-object)
-    - [OAuth Flows Object](#oauth-flows-object)
-    - [OAuth Flow Object](#oauth-flow-object)
-    - [Server Bindings Object](#server-bindings-object)
-    - [Parameters Object](#parameters-object)
-    - [Parameter Object](#parameter-object)
-    - [Channel Bindings Object](#channel-bindings-object)
-    - [Operation Bindings Object](#operation-bindings-object)
-    - [Message Bindings Object](#message-bindings-object)
-    - [Correlation ID Object](#correlation-id-object)
-    - [Specification Extensions](#specification-extensions)
-
-<!-- /TOC -->
 
 ## <a name="definitions"></a>Definitions
 
@@ -607,7 +551,7 @@ An object containing all the [Channel Object](#channel-object) definitions the [
 
 Field Pattern | Type | Description
 ---|:---:|---
-<a name="channels-object-channel"></a>{channelId} | [Channel Object](#channel-object) \| [Reference Object](#reference-object) | An identifier for the described channel. The `channelId` value is **case-sensitive**. Tools and libraries MAY use the `channelId` to uniquely identify a channel, therefore, it is RECOMMENDED to follow common programming naming conventions.
+<a name="channels-object-channel"></a>\{channelId} | [Channel Object](#channel-object) \| [Reference Object](#reference-object) | An identifier for the described channel. The `channelId` value is **case-sensitive**. Tools and libraries MAY use the `channelId` to uniquely identify a channel, therefore, it is RECOMMENDED to follow common programming naming conventions.
 
 ##### Channels Object Example
 

--- a/spec/asyncapi.md
+++ b/spec/asyncapi.md
@@ -59,6 +59,62 @@ operations:
 
 Aside from the issues mentioned above, there may also be infrastructure configuration that is not represented here. For instance, a system may use a read-only channel for receiving messages, a different one for sending them, and an intermediary process that will forward messages from one channel to the other.
 
+## Table of Contents
+<!-- TOC depthFrom:2 depthTo:4 withLinks:1 updateOnSave:0 orderedList:0 -->
+
+- [Definitions](#definitions)
+  - [Server](#definitions-server)
+  - [Application](#definitions-application)
+  - [Sender](#definitions-sender)
+  - [Receiver](#definitions-receiver)
+  - [Message](#definitions-message)
+  - [Channel](#definitions-channel)
+  - [Protocol](#definitions-protocol)
+- [Specification](#specification)
+  - [Format](#format)
+  - [File Structure](#file-structure)
+  - [Absolute URLs](#absolute-urls)
+  - [Schema](#schema)
+    - [AsyncAPI Object](#a2s-object)
+    - [AsyncAPI Version String](#a2s-versionString)
+    - [Identifier](#a2s-id-string)
+    - [Info Object](#info-object)
+    - [Contact Object](#contact-object)
+    - [License Object](#license-object)
+    - [Servers Object](#servers-object)
+    - [Server Object](#server-object)
+    - [Server Variable Object](#server-variable-object)
+    - [Default Content Type](#default-content-type-string)
+    - [Channels Object](#channels-object)
+    - [Channel Object](#channel-object)
+    - [Operations Object](#operations-object)
+    - [Operation Object](#operation-object)
+    - [Operation Trait Object](#operation-trait-object)
+    - [Operation Reply Object](#operation-reply-object)
+    - [Operation Reply Address Object](#operation-reply-address-object)
+    - [Message Object](#message-object)
+    - [Message Trait Object](#message-trait-object)
+    - [Message Example Object](#message-example-object)
+    - [Tags Object](#tags-object)
+    - [Tag Object](#tag-object)
+    - [External Documentation Object](#external-documentation-object)
+    - [Components Object](#components-object)
+    - [Reference Object](#reference-object)
+    - [Multi Format Schema Object](#multiFormat-schema-object)
+    - [Schema Object](#schema-object)
+    - [Security Scheme Object](#security-scheme-object)
+    - [OAuth Flows Object](#oauth-flows-object)  
+    - [OAuth Flow Object](#oauth-flow-object)
+    - [Server Bindings Object](#server-bindings-object)
+    - [Parameters Object](#parameters-object)
+    - [Parameter Object](#parameter-object)
+    - [Channel Bindings Object](#channel-bindings-object)
+    - [Operation Bindings Object](#operation-bindings-object)
+    - [Message Bindings Object](#message-bindings-object)
+    - [Correlation ID Object](#correlation-id-object)
+    - [Specification Extensions](#specification-extensions)
+
+<!-- /TOC -->
 
 ## <a name="definitions"></a>Definitions
 
@@ -2587,6 +2643,7 @@ availableScopes:
 
 ### <a name="correlation-id-object"></a>Correlation ID Object
 
+An object that specifies an identifier at design time that can used for message tracing and correlation.
 
 For specifying and computing the location of a Correlation ID, a [runtime expression](#runtime-expression) is used.
 


### PR DESCRIPTION
This PR converts markdown anchors and their internal references from camelCase to kebab-case to restore GitHub navigation behavior.

Changes are limited to anchor names and references only. No content or semantics were modified.

Fixes #1144