### PR TITLE
fix(docs): correct typo and updated expired SchemaStore link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ In this directory, you can find some examples of AsyncAPI documents.
 
 ## File naming
 
-You may notice `asyncapi` in the the name of each example. We recommend doing the same with your AsyncAPI document. This way you enable features like documentation display on node hover, auto completion and validation of your AsyncAPI documents in IDEs like VSCode or IntelliJ IDEA. IDEs integrate with [SchemaStore](https://www.schemastore.org/json/) where AsyncAPI specification JSON Schema files are referenced. Some IDEs do it by default, some, like VSCode require you to install additional extensions, like `YAML` extension.
+You may notice `asyncapi` in the name of each example. We recommend doing the same with your AsyncAPI document. This way you enable features like documentation display on node hover, auto completion and validation of your AsyncAPI documents in IDEs like VSCode or IntelliJ IDEA. IDEs integrate with [SchemaStore](https://www.schemastore.org/) where AsyncAPI specification JSON Schema files are referenced. Some IDEs do it by default, some, like VSCode require you to install additional extensions, like `YAML` extension.
 
 ## Editors
 


### PR DESCRIPTION
Fixes asyncapi/spec#1146

Affected path: spec/examples/README.md


- Corrected a duplicate word typo
- Updated an expired SchemaStore documentation link

No content changes beyond these fixes.
