### PR TITLE
fix: prevent baseDoc mutation causing cross-contamination in validation

### DIFF
--- a/scripts/validation/embedded-examples-validation.js
+++ b/scripts/validation/embedded-examples-validation.js
@@ -99,8 +99,23 @@ const baseDocPath = './base-doc-combined.json';
 
 const baseDoc = JSON.parse(fs.readFileSync(baseDocPath, 'utf8'));
 
+/**
+ * Creates a deep copy of the base document to ensure each validation
+ * operates on an isolated copy, preventing cross-contamination between
+ * example validations.
+ *
+ * @param {object} doc - The document to clone
+ * @returns {object} A deep copy of the document
+ */
+function cloneDocument(doc) {
+  return JSON.parse(JSON.stringify(doc));
+}
+
 const validationPromises = combinedData.map(async (item) => {
-  const updatedDocument = applyUpdates([item], baseDoc);
+  // Create a fresh copy of baseDoc for each validation to prevent mutations
+  // from affecting subsequent validations
+  const baseDocCopy = cloneDocument(baseDoc);
+  const updatedDocument = applyUpdates([item], baseDocCopy);
 
   await validateParser(updatedDocument, `${item.name}-${item.format}-format`);
 });


### PR DESCRIPTION
fix: prevent baseDoc mutation causing cross-contamination in validation

**Related issue(s):**
Fixes #1153

1. The validation script was mutating the `baseDoc` object across all validation iterations. The `baseDoc` was passed by reference to `applyUpdates()`, which mutates the document via `jsonpointer.set()` and `mergePatch.apply()`. Since the same object reference was reused across all `map()` iterations, each example was being validated against a document that included patches from all previous examples, leading to incorrect validation results.

2. To fix this issue, a `cloneDocument()` helper function was created that performs a deep copy of the base document. This function uses `JSON.parse(JSON.stringify())` to create an isolated copy, ensuring each validation operates independently.

3. The validation loop was modified to create a fresh copy of `baseDoc` for each iteration. This ensures that Example 1 validates against `baseDoc + Example1's patch`, Example 2 validates against `baseDoc + Example2's patch` in isolation, and each validation is independent and not affected by other examples.

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->
