### PR TITLE
fix: prevent baseDoc mutation causing cross-contamination in validation

### DIFF
--- a/scripts/validation/embedded-examples-validation.js
+++ b/scripts/validation/embedded-examples-validation.js
@@ -100,7 +100,9 @@ const baseDocPath = './base-doc-combined.json';
 const baseDoc = JSON.parse(fs.readFileSync(baseDocPath, 'utf8'));
 
 const validationPromises = combinedData.map(async (item) => {
-  const updatedDocument = applyUpdates([item], baseDoc);
+  // Create a deep copy of baseDoc for each validation to prevent cross-contamination
+  const baseDocCopy = JSON.parse(JSON.stringify(baseDoc));
+  const updatedDocument = applyUpdates([item], baseDocCopy);
 
   await validateParser(updatedDocument, `${item.name}-${item.format}-format`);
 });


### PR DESCRIPTION
## Summary

Fixed a critical bug in the validation script where the `baseDoc` object was being mutated and reused across all validation iterations, causing cross-contamination between examples.

### The Problem

In [embedded-examples-validation.js:102-106](https://github.com/asyncapi/spec/blob/master/scripts/validation/embedded-examples-validation.js#L102-L106), the `baseDoc` object was passed by reference to `applyUpdates()`, which mutates it directly via `jsonpointer.set()` and `mergePatch.apply()`. This caused:

- Example 1 to be validated against: `baseDoc + Example1's patch`  ✅
- Example 2 to be validated against: `baseDoc + Example1's patch + Example2's patch`  ❌
- Example N to be validated against: `baseDoc + patches from all previous examples`  ❌

This led to incorrect validation results (false positives or false negatives).

### The Solution

Each validation now operates on a fresh deep copy of `baseDoc`:

```javascript
const baseDocCopy = JSON.parse(JSON.stringify(baseDoc));
const updatedDocument = applyUpdates([item], baseDocCopy);
```

This ensures that each example is validated independently:
- Example 1: `baseDoc + Example1's patch` ✅
- Example 2: `baseDoc + Example2's patch` ✅
- Example N: `baseDoc + ExampleN's patch` ✅

### Testing

✅ Validated all 89 embedded examples successfully
✅ No validation errors or cross-contamination

Fixes #1153

## Test plan

- [x] Ran `npm run validate:examples` in `scripts/validation/`
- [x] Verified all 89 examples validated correctly
- [x] Confirmed no cross-contamination between validations
