### PR TITLE
feat: add CloudEvents Message Traits as a component

### DIFF
--- a/components/cloudevents.yml
+++ b/components/cloudevents.yml
@@ -1,0 +1,67 @@
+asyncapi: 3.0.0
+info:
+  title: CloudEvents Message Traits
+  version: 1.0.0
+  description: |
+    Official AsyncAPI [CloudEvents](https://github.com/cloudevents/spec/tree/main/cloudevents) message traits for various protocols.
+    
+    The propper usage is described here: https://www.asyncapi.com/docs/reference/message-formats/cloudevents.
+
+components:
+  messageTraits:
+    cloudevents-headers-kafka-binary:
+      summary: Message headers for CloudEvents in binary content mode with Kafka (see https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/kafka-protocol-binding.md)
+      headers:
+        type: object
+        required:
+        - ce_id
+        - ce_source
+        - ce_specversion
+        - ce_type
+        properties:
+          ce_id:
+            type: string
+            minLength: 1
+            description: Identifies the event.
+            examples:
+            - "1234-1234-1234"
+          ce_source:
+            type: string
+            format: uri-reference
+            minLength: 1
+            description: Identifies the context in which an event happened.
+            examples:
+            - "https://example.com/storage/tenant/container"
+          ce_specversion:
+            type: string
+            description: The version of the CloudEvents specification which the event uses.
+            enum:
+            - "1.0"
+          ce_type:
+            type: string
+            minLength: 1
+            description: Describes the type of event related to the originating occurrence.
+            examples:
+            - "com.example.someevent"
+          content-type:
+            type: string
+            description: Kafka default field to describing the content type of the data. Must be mapped directly to the CloudEvents datacontenttype attribute.
+            examples:
+            - "application/avro"
+            - "application/json;charset=utf-8"
+          ce_dataschema:
+            type: string
+            description: Identifies the schema that data adheres to.
+            examples:
+            - "http://registry.com/schema/v1/much.json"
+          ce_subject:
+            type: string
+            description: Describes the subject of the event in the context of the event producer (identified by source)
+            examples:
+            - mynewfile.jpg
+          ce_time:
+            type: string
+            format: date-time
+            description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+            examples:
+            - "2018-04-05T17:31:00Z"


### PR DESCRIPTION

---
title: "add CloudEvents Message Traits as a component"
---

- Add a CloudEvents Message Traits as a new official component that can be referred to as discussed in https://github.com/asyncapi/spec-json-schemas/issues/623
- This PR should come together with a PR in the docs repo https://github.com/asyncapi/website/pull/4819
 to describe the component and how to use it, suggested URL: `https://www.asyncapi.com/docs/reference/message-formats/cloudevents`. 
---

**Related issue(s):**
- Problem and discussion: https://github.com/asyncapi/spec-json-schemas/issues/623
- https://github.com/asyncapi/spec/issues/432 describes an alternative approach, with native support for envelopes
- Intermediate solution in the CloudEvents repo was discussed in https://github.com/cloudevents/spec/issues/1276 and merged into the cloudevents repo: https://github.com/cloudevents/spec/blob/main/cloudevents/working-drafts/asyncapi.md
- Documentation: https://github.com/asyncapi/website/pull/4819
---

<!--

1. Make sure you craft a good description!
2. Is it a Strawman proposal (RFC 0)? Add the 💭 Strawman (RFC 0) label.
3. Is it a Proposal (RFC 1)? Add the 💡 Proposal (RFC 1) label.
4. Is it just an editorial fix, typo, or something that doesn't change the spec behavior? Add the ✏️ Editorial label.

-->